### PR TITLE
Make filterData optional in PrivateAttributionImpressionOptions

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -474,7 +474,7 @@ navigator.privateAttribution.saveImpression({
 <xmp class=idl>
 dictionary PrivateAttributionImpressionOptions {
   required unsigned long histogramIndex;
-  required unsigned long filterData;
+  unsigned long filterData;
   required DOMString conversionSite;
   unsigned long lifetimeDays;
 };

--- a/api.bs
+++ b/api.bs
@@ -474,7 +474,7 @@ navigator.privateAttribution.saveImpression({
 <xmp class=idl>
 dictionary PrivateAttributionImpressionOptions {
   required unsigned long histogramIndex;
-  unsigned long filterData;
+  unsigned long filterData = 0;
   required DOMString conversionSite;
   unsigned long lifetimeDays;
 };


### PR DESCRIPTION
It is already optional in PrivateAttributionConversionOptions, and described as optional in the detailed description of PrivateAttributionImpressionOptions.