### PR TITLE
Rename PrivateAttribution.aggregators to aggregationServices

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -429,7 +429,7 @@ interface PrivateAttributionAggregationServices {
 
 [SecureContext, Exposed=Window]
 interface PrivateAttribution {
-  readonly attribute PrivateAttributionAggregationServices aggregators;
+  readonly attribute PrivateAttributionAggregationServices aggregationServices;
 };
 </xmp>
 
@@ -616,7 +616,7 @@ The arguments to <a method for=PrivateAttribution>measureConversion()</a> are as
   <dt><dfn>aggregator</dfn></dt>
   <dd>
     A selection from the [=aggregation services=] that can be found in <a
-    attribute for=PrivateAttribution>aggregators</a>.
+    attribute for=PrivateAttribution>aggregationServices</a>.
   </dd>
   <dt><dfn>epsilon</dfn></dt>
   <dd>The amount of [=privacy budget=] to expend on this [=conversion report=].</dd>


### PR DESCRIPTION
To match the surrounding prose, and for consistency with the names of the corresponding IDL types.

Fixes #66


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/67.html" title="Last updated on Feb 11, 2025, 1:29 PM UTC (f8bc9e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/67/764f599...apasel422:f8bc9e6.html" title="Last updated on Feb 11, 2025, 1:29 PM UTC (f8bc9e6)">Diff</a>