### PR TITLE
Restore a subsection of privacy considerations

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1516,24 +1516,25 @@ this difference cannot be detected
 by the site receiving the conversion report.
 
 
-## Placing Identifiers in Filter Data ## {#privacy-filter-data}
+## Including Identifying Information with Saved Impressions ## {#privacy-impression-store}
 
-Because {{PrivateAttributionConversionOptions/filterData}}
-may contain arbitrary information, it is possible to place identifiers
-(e.g. of a user or an advertisement) in this field.
+Sites are able to encode some amount of data
+in impressions,
+using {{PrivateAttributionConversionOptions/filterData}}
+or other fields.
+The API does not prevent sites from encoding user identifiers
+in these fields.
 It is important that identifiers in the filter data cannot be (mis)used
 for arbitrary tracking. The following measures mitigate this risk:
 
 *   The impression store can not be read directly.
-    Thus, identifiers in filter data are only usable for tracking
+    Thus, identifiers are only usable for tracking
     to the extent information about them
     is revealed in [=conversion reports=].
-*   Filter data are scoped
-    to a specific set of impression and conversion sites.
-    It is not possible to use the filter data for tracking across
-    arbitrary sites.
+*   The information in [=conversion reports=] is only revealed
+    after aggregation and the addition of noise.
 *   Users have the ability to [[#impression-store-clearing|clear the impression store]].
-*   Filter data are not written to the impression store
+*   No impressions are saved to the impression store
     when the Private Attribution API is [[#opt-out|disabled]].
 
 

--- a/api.bs
+++ b/api.bs
@@ -1516,6 +1516,27 @@ this difference cannot be detected
 by the site receiving the conversion report.
 
 
+## Placing Identifiers in Filter Data ## {#privacy-filter-data}
+
+Because {{PrivateAttributionConversionOptions/filterData}}
+may contain arbitrary information, it is possible to place identifiers
+(e.g. of a user or an advertisement) in this field.
+It is important that identifiers in the filter data cannot be (mis)used
+for arbitrary tracking. The following measures mitigate this risk:
+
+*   The impression store can not be read directly.
+    Thus, identifiers in filter data are only usable for tracking
+    to the extent information about them
+    is revealed in [=conversion reports=].
+*   Filter data are scoped
+    to a specific set of impression and conversion sites.
+    It is not possible to use the filter data for tracking across
+    arbitrary sites.
+*   Users have the ability to [[#impression-store-clearing|clear the impression store]].
+*   Filter data are not written to the impression store
+    when the Private Attribution API is [[#opt-out|disabled]].
+
+
 ## Use in Third-party Contexts ## {#privacy-third-party-contexts}
 
 The Private Attribution API is available even in third-party contexts.

--- a/api.bs
+++ b/api.bs
@@ -1524,8 +1524,11 @@ using {{PrivateAttributionConversionOptions/filterData}}
 or other fields.
 The API does not prevent sites from encoding user identifiers
 in these fields.
-It is important that identifiers in the filter data cannot be (mis)used
-for arbitrary tracking. The following measures mitigate this risk:
+The attribution process can use this data
+when constructing a [=conversion report=],
+which implies some risk of that identifying information
+becoming available to the site that receives that report.
+The following measures mitigate this risk:
 
 *   The impression store can not be read directly.
     Thus, identifiers are only usable for tracking

--- a/api.bs
+++ b/api.bs
@@ -1530,7 +1530,7 @@ which implies some risk of that identifying information
 becoming available to the site that receives that report.
 The following measures mitigate this risk:
 
-*   The impression store can not be read directly.
+*   The impression store cannot be read directly.
     Thus, identifiers are only usable for tracking
     to the extent information about them
     is revealed in [=conversion reports=].


### PR DESCRIPTION
This text was removed when replacing the ad identifier with filter data. Since I think the consideration remains more or less the same, this change restores the text, modifying it to refer to filter data.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/pull/71.html" title="Last updated on Feb 20, 2025, 9:52 PM UTC (688a4a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/71/0609f54...688a4a3.html" title="Last updated on Feb 20, 2025, 9:52 PM UTC (688a4a3)">Diff</a>