### PR TITLE
Drop non-standard IDL `Throws` extended attribute

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -488,7 +488,7 @@ dictionary PrivateAttributionImpressionOptions {
 
 [SecureContext, Exposed=Window]
 partial interface PrivateAttribution {
-  [Throws] undefined saveImpression(PrivateAttributionImpressionOptions options);
+  undefined saveImpression(PrivateAttributionImpressionOptions options);
 };
 </xmp>
 
@@ -606,7 +606,7 @@ dictionary PrivateAttributionConversionOptions {
 
 [SecureContext, Exposed=Window]
 partial interface PrivateAttribution {
-  [Throws] Promise<Uint8Array> measureConversion(PrivateAttributionConversionOptions options);
+  Promise<Uint8Array> measureConversion(PrivateAttributionConversionOptions options);
 };
 </xmp>
 


### PR DESCRIPTION
WebIDL does not define a `Throws` extended attribute for now. The possibility to define it is tracked in https://github.com/whatwg/webidl/issues/603


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/ppa/pull/91.html" title="Last updated on Feb 17, 2025, 1:42 AM UTC (fa2e9f4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/91/764f599...tidoust:fa2e9f4.html" title="Last updated on Feb 17, 2025, 1:42 AM UTC (fa2e9f4)">Diff</a>