### PR TITLE
Remove not-Group from metadata

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -13,7 +13,6 @@ Complain About: accidental-2119 yes, missing-example-ids yes
 Markup Shorthands: markdown yes, css no, dfn yes
 Assume Explicit For: yes
 Org: W3C
-!Group: pat
 Status: ED
 Level: None
 </pre>
@@ -883,7 +882,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
         1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
-        1.  Let |budgetOk| be the result of [=deduct privacy budget=] 
+        1.  Let |budgetOk| be the result of [=deduct privacy budget=]
             with |key|, |options|.{{PrivateAttributionConversionOptions/epsilon}},
             |options|.{{PrivateAttributionConversionOptions/value}},
             and |options|.{{PrivateAttributionConversionOptions/maxValue}}.


### PR DESCRIPTION
According to Tab:

> The only purpose of Group is to opt into group-specific boilerplate, so there's no reason to list a Group value that's not present in the doctypes file.

-- https://github.com/speced/bikeshed/issues/3022#issuecomment-2672864705


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/pull/94.html" title="Last updated on Feb 20, 2025, 10:51 PM UTC (3f6206b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/94/75d1650...3f6206b.html" title="Last updated on Feb 20, 2025, 10:51 PM UTC (3f6206b)">Diff</a>