### PR TITLE
Fix broken "obtain a site" links

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1681,6 +1681,7 @@ The privacy architecture is courtesy of the authors of [[PPA-DP]].
 
 <pre class=anchors>
 urlPrefix: https://html.spec.whatwg.org/; spec: html; type: dfn
+    text: obtain a site
     text: origin; url: #concept-origin
     text: relevant settings object
     text: same site
@@ -1688,7 +1689,6 @@ urlPrefix: https://html.spec.whatwg.org/; spec: html; type: dfn
     text: top-level origin; url: #concept-environment-top-level-origin
 urlPrefix: https://infra.spec.whatwg.org/; spec: infra; type: dfn;
     text: user agent
-    text: obtain a site
     text: set; url: #sets
 </pre>
 <pre class=biblio>


### PR DESCRIPTION
Fixes #98


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/100.html" title="Last updated on Feb 24, 2025, 1:15 PM UTC (1e3050d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/100/09e9a68...apasel422:1e3050d.html" title="Last updated on Feb 24, 2025, 1:15 PM UTC (1e3050d)">Diff</a>