### PR TITLE
Add procedures for parsing site names from strings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Privacy-Preserving Attribution
 
-A_A [Deliverable](https://www.w3.org/2024/11/wg-pat-charter.html#private-attribution) of the [Private Advertising Technology Working Group](https://www.w3.org/groups/wg/pat/) of [W3C](https://www.w3.org/)._
+_A [Deliverable](https://www.w3.org/2024/11/wg-pat-charter.html#private-attribution) of the [Private Advertising Technology Working Group](https://www.w3.org/groups/wg/pat/) of [W3C](https://www.w3.org/)._
 
-Attribution is the name given to the measurement system used in advertising.  It is called attribution because it seeks to attribute value from an outcome (like someone buying stuff) to advertisements.
+Attribution is the name given to the measurement system used in advertising. It is called attribution because it seeks to attribute value from an outcome (like someone buying stuff) to advertisements.
 
 This repository contains [a specification](https://w3c.github.io/ppa/) that describes an API that would be presented by a browser to websites.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Privacy-Preserving Attribution
 
-_A [Deliverable](https://www.w3.org/2024/11/wg-pat-charter.html#private-attribution) of the [Private Advertising Technology Working Group](https://www.w3.org/groups/wg/pat/) of [W3C](https://www.w3.org/).
+A_A [Deliverable](https://www.w3.org/2024/11/wg-pat-charter.html#private-attribution) of the [Private Advertising Technology Working Group](https://www.w3.org/groups/wg/pat/) of [W3C](https://www.w3.org/)._
 
 Attribution is the name given to the measurement system used in advertising.  It is called attribution because it seeks to attribute value from an outcome (like someone buying stuff) to advertisements.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 # Privacy-Preserving Attribution
 
-_A [Proposal](https://patcg.github.io/charter.html#proposals)
-for the [Private Advertising Technology Community^WWorking Group](https://patcg.github.io/)._
+_A [Deliverable](https://www.w3.org/2024/11/wg-pat-charter.html#private-attribution) of the [Private Advertising Technology Working Group](https://www.w3.org/groups/wg/pat/) of [W3C](https://www.w3.org/).
 
-Attribution is the name given to the measurement system used in advertising.
-It is called attribution because it seeks to attribute value from
-an outcome (like someone buying stuff)
-to advertisements.
+Attribution is the name given to the measurement system used in advertising.  It is called attribution because it seeks to attribute value from an outcome (like someone buying stuff) to advertisements.
 
-This repository contains [a specification](https://w3c.github.io/ppa/)
-that describes an API that would be presented by a browser to websites.
+This repository contains [a specification](https://w3c.github.io/ppa/) that describes an API that would be presented by a browser to websites.
 
-The specification contains all of the details.  There is no explainer.
-All the explanation can be found up front, before it gets into the gory details.
+The specification contains all of the details. There is no [explainer](https://tag.w3.org/explainers/). All the explanation can be found up front, before it gets into the gory details.

--- a/api.bs
+++ b/api.bs
@@ -461,9 +461,9 @@ and impressions are not scoped to a single aggregation service.
     "https://aggregator.example/dap",
     "https://example.com/aggregator",
   ];
-  const supportedServices = navigator.privateAttribution?.aggregationServices;
+  const supportedServices = navigator.privateAttribution?.aggregationServices?.values();
   const serviceUrl = preferredServices.find(preference => {
-    supportedServices?.some(svc => svc.url === preference)
+    supportedServices.some(svc => svc.url === preference)
   })?.url;
   </xmp>
 

--- a/api.bs
+++ b/api.bs
@@ -1020,10 +1020,13 @@ and <a dictionary lt=PrivateAttributionConversionOptions>|options|</a>:
              [=obtain a site|obtaining a site=] from the [=origin=].
         <!-- TODO: the intermediary site is currently unused -->
 1. Validate the page-supplied API inputs:
-    1.  If <a dict-member for=PrivateAttributionConversionOptions>logic</a>
-        is specified, and the value is anything other than
-        <a enum-value for=PrivateAttributionLogic>"last-touch"</a>,
-        throw a {{TypeError}}.
+    1.  Switch on the value of <a dict-member for=PrivateAttributionConversionOptions>logic</a>:
+        <dl class="switch">
+        </dl>
+        :   <a enum-value for=PrivateAttributionLogic>"last-touch"</a>
+        ::  If <a dict-member for=PrivateAttributionConversionOptions>value</a>
+            is greater than <a dict-member for=PrivateAttributionConversionOptions>maxValue</a>,
+            throw a {{RangeError}}.
     1. If |options|.{{PrivateAttributionConversionOptions/lookbackDays}} is 0,
         throw a {{RangeError}}.
 1.  Let |report| be an [=create an all-zero histogram|all-zero histogram=].

--- a/api.bs
+++ b/api.bs
@@ -461,10 +461,8 @@ and impressions are not scoped to a single aggregation service.
     "https://aggregator.example/dap",
     "https://example.com/aggregator",
   ];
-  const supportedServices = navigator.privateAttribution?.aggregationServices?.values();
-  const serviceUrl = preferredServices.find(preference => {
-    supportedServices.some(svc => svc.url === preference)
-  })?.url;
+  const supportedServices = navigator.privateAttribution?.aggregationServices;
+  const serviceUrl = preferredServices.find(url => supportedServices?.has(url));
   </xmp>
 
   If the user agent supports the URL
@@ -479,13 +477,12 @@ and impressions are not scoped to a single aggregation service.
 enum PrivateAttributionProtocol { "dap-12-histogram", "tee-00" };
 
 dictionary PrivateAttributionAggregationService {
-  required USVString url;
   required DOMString protocol;
 };
 
 [SecureContext, Exposed=Window]
 interface PrivateAttributionAggregationServices {
-  readonly setlike<PrivateAttributionAggregationService>;
+  readonly maplike<USVString, PrivateAttributionAggregationService>;
 };
 
 [SecureContext, Exposed=Window]
@@ -494,16 +491,11 @@ interface PrivateAttribution {
 };
 </xmp>
 
-The <a attribute for=PrivateAttribution>aggregationServices</a> attribute
-contains the following information about each supported aggregation service:
+The <a attribute for=PrivateAttribution>aggregationServices</a> attribute is
+a mapping from URLs that identify an [=aggregation service=] to metadata about
+that service:
 
 <dl dfn-for=PrivateAttributionAggregationService dfn-type=dict-member>
-  <dt><dfn>url</dfn></dt>
-  <dd>
-    A URL that identifies an [=aggregation service=].
-    This value is passed as the {{PrivateAttributionConversionOptions/aggregationService}} parameter
-    to <a method for=PrivateAttribution>measureConversion()</a> to select the identified aggregation service.
-  </dd>
   <dt><dfn>protocol</dfn></dt>
   <dd>
     The {{PrivateAttributionProtocol|protocol}} that the [=aggregation service=] uses.
@@ -514,6 +506,9 @@ contains the following information about each supported aggregation service:
     without also specifying the choice of protocol.
   </dd>
 </dl>
+
+The URL is passed as the {{PrivateAttributionConversionOptions/aggregationService}} parameter
+to <a method for=PrivateAttribution>measureConversion()</a> to select the identified aggregation service.
 
 The <dfn enum>PrivateAttributionProtocol</dfn> describes the submission protocol
 used by different [=aggregation services=].  This document defines two protocols:

--- a/api.bs
+++ b/api.bs
@@ -935,13 +935,13 @@ that are used to manage the expenditure of [=privacy budgets=]:
     It is updated by [=deduct privacy budget=].
 
 
-*   A singleton [=last browsing history clear=] value
-    that tracks when the browsing activity for a [=site=] was last cleared.
-
 *   The [=epoch start store=] records when each [=epoch=] starts
     for [=impression sites=].
     This store is initialized as a side effect
     of invoking <a method for=PrivateAttribution>saveImpression()</a>.
+
+*   A singleton [=last browsing history clear=] value
+    that tracks when the browsing activity for a [=site=] was last cleared.
 
 <p class=note>
 Like the [=impression store=],

--- a/api.bs
+++ b/api.bs
@@ -733,6 +733,10 @@ dictionary PrivateAttributionConversionOptions {
   unsigned long maxValue = 1;
 };
 
+enum PrivateAttributionLogic {
+  "last-touch",
+};
+
 dictionary PrivateAttributionConversionResult {
   required Uint8Array report;
 };
@@ -1038,12 +1042,6 @@ which determines how the [=conversion value=] is allocated to histogram buckets.
 The <a method for=PrivateAttribution>measureConversion()</a> function
 accepts a <a dict-member for=PrivateAttributionConversionOptions>logic</a> parameter
 that specifies the [=attribution logic=].
-
-<xmp class=idl>
-enum PrivateAttributionLogic {
-  "last-touch",
-};
-</xmp>
 
 Each attribution logic specifies a process for allocating values to histogram buckets,
 after the [=common matching logic=] is applied and privacy budgeting occurs.

--- a/api.bs
+++ b/api.bs
@@ -607,6 +607,12 @@ The arguments to <a method for=PrivateAttribution>saveImpression()</a> are as fo
   </dd>
 </dl>
 
+The <dfn for=PrivateAttribution method>saveImpression(|options|)</dfn> method
+causes the user agent to invoke the [=save an impression=] algorithm
+with [=this=]'s [=relevant settings object=]
+and the provided |options|.
+
+
 ## Requesting Attribution for a Conversion ## {#measure-conversion}
 
 The <dfn method for=PrivateAttribution>measureConversion()</dfn> method
@@ -776,6 +782,11 @@ The arguments to <a method for=PrivateAttribution>measureConversion()</a> are as
     to expend on this [=conversion report=].
   </dd>
 </dl>
+
+The <dfn for=PrivateAttribution method>measureConversion(|options|)</dfn> method
+causes the user agent to invoke the [=measure a conversion=] algorithm
+with [=this=]'s [=relevant settings object=]
+and the provided |options|.
 
 
 ## Permissions Policy Integration ## {#permission-policy}
@@ -954,9 +965,10 @@ To <dfn>deduct privacy budget</dfn> given a [=privacy budget key=] |key|,
 ## Save Impression Algorithm ## {#save-impression-api-operation}
 
 To <dfn>save an impression</dfn>,
-given <a dictionary lt=PrivateAttributionImpressionOptions>|options|</a>:
+given an [=environment settings object=] |settings|
+and given <a dictionary lt=PrivateAttributionImpressionOptions>|options|</a>:
 
-1.  Collect the implicit API inputs from the [=relevant settings object=]:
+1.  Collect the implicit API inputs from |settings|:
     1.  The timestamp is set to the [=current high resolution time=].
     1.  The [=impression site=] is set to the result of
         [=obtain a site|obtaining a site=] from the [=top-level origin=].
@@ -982,9 +994,10 @@ API is [[#opt-out|disabled]].
 ## Measure Conversion Algorithm ## {#measure-conversion-api-operation}
 
 To <dfn>measure a conversion</dfn>,
-given <a dictionary lt=PrivateAttributionConversionOptions>|options|</a>:
+given a [=environment settings object=] |settings|
+and <a dictionary lt=PrivateAttributionConversionOptions>|options|</a>:
 
-1.  Collect the implicit API inputs from the [=relevant settings object=]:
+1.  Collect the implicit API inputs from |settings|:
     1.  Let |now| be the [=current high resolution time=].
     1.  Let |topLevelSite| (the [=conversion site=]) be the result of
         [=obtain a site|obtaining a site=] from the [=top-level origin=].

--- a/api.bs
+++ b/api.bs
@@ -479,7 +479,7 @@ and impressions are not scoped to a single aggregation service.
 enum PrivateAttributionProtocol { "dap-12-histogram", "tee-00" };
 
 dictionary PrivateAttributionAggregationService {
-  required DOMString url;
+  required USVString url;
   required DOMString protocol;
 };
 
@@ -543,7 +543,7 @@ navigator.privateAttribution.saveImpression({
 dictionary PrivateAttributionImpressionOptions {
   required unsigned long histogramIndex;
   unsigned long filterData = 0;
-  required DOMString conversionSite;
+  required USVString conversionSite;
   unsigned long lifetimeDays = 30;
 };
 
@@ -685,7 +685,7 @@ contribute to the histogram, i.e., will be uniformly zero.
 
 <xmp class=idl>
 dictionary PrivateAttributionConversionOptions {
-  required DOMString aggregationService;
+  required USVString aggregationService;
   double epsilon = 1.0;
 
   required unsigned long histogramSize;

--- a/api.bs
+++ b/api.bs
@@ -1166,7 +1166,7 @@ if the user has opted out of collection of diagnostic data.
     * Histogram size
     * [=Conversion site=] for [=impressions=]
     * [=Impression site=] for [=conversions=]
-    * Histogram indexes
+    * [=impression/histogram index|Histogram indexes=]
 
 # Aggregation # {#aggregation}
 
@@ -1698,7 +1698,7 @@ aggregation.
 An important mitigation against malicious use
 of the Private Attribution APIs is the explicit specification
 of eligible conversion sites when registering an impression,
-and of eligible impression sites and histogram indexes
+and of eligible impression sites and [=impression/histogram indexes=]
 when registering a conversion.
 This prevents impressions on arbitrary malicious sites
 from interfering with attribution to the intended set

--- a/api.bs
+++ b/api.bs
@@ -896,7 +896,7 @@ the [=impression store=] may need to be
 updated to refer to the [=privacy budget store=] as well.
 
 
-A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the folowing items:
+A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items:
 
 <dl dfn-for="privacy budget key">
 : <dfn ignore>epoch</dfn>

--- a/api.bs
+++ b/api.bs
@@ -1024,9 +1024,12 @@ and <a dictionary lt=PrivateAttributionConversionOptions>|options|</a>:
         <dl class="switch">
         </dl>
         :   <a enum-value for=PrivateAttributionLogic>"last-touch"</a>
-        ::  If <a dict-member for=PrivateAttributionConversionOptions>value</a>
-            is greater than <a dict-member for=PrivateAttributionConversionOptions>maxValue</a>,
-            throw a {{RangeError}}.
+        ::  Perform the following steps:
+            1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a> is 0,
+                throw a {{RangeError}}.
+            1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a>
+                is greater than <a dict-member for=PrivateAttributionConversionOptions>maxValue</a>,
+                throw a {{RangeError}}.
     1. If |options|.{{PrivateAttributionConversionOptions/lookbackDays}} is 0,
         throw a {{RangeError}}.
 1.  Let |report| be an [=create an all-zero histogram|all-zero histogram=].

--- a/api.bs
+++ b/api.bs
@@ -530,14 +530,37 @@ used by different [=aggregation services=].  This document defines two protocols
 The <dfn method for=PrivateAttribution>saveImpression()</dfn> method requests
 that the [=user agent=] record an [=impression=] in the [=impression store=].
 
-<pre>
-navigator.privateAttribution.saveImpression({
-  histogramIndex: 3,
-  filterData: 2,
-  conversionSite: "advertiser.example",
-  lifetimeDays: 7,
-});
-</pre>
+<div class=example id=ex-save-impression>
+  A site that shows an advertisement for an advertiser
+  can save an impression.
+
+  In this case, the site saves the impression directly,
+  identifying the advertiser (`advertiser.example`)
+  and including information that is negotiated by the advertiser.
+  In the following example,
+  this includes the {{PrivateAttributionImpressionOptions/filterData}} value (2)
+  that the advertiser might later use to select this advertisement,
+  the index of the histogram ({{PrivateAttributionImpressionOptions/histogramIndex}} = 3)
+  into which to include any attributed value,
+  and a retention period ({{PrivateAttributionImpressionOptions/lifetimeDays}} = 7)
+  that is at least as long as the advertiser requires.
+
+  <xmp highlight=js>
+    navigator.privateAttribution.saveImpression({
+      histogramIndex: 3,
+      filterData: 2,
+      conversionSite: "advertiser.example",
+      lifetimeDays: 7,
+    });
+  </xmp>
+
+  Alternatively, an intermediary,
+  such as a Supply-Side Platform (SSP) or Demand-Side Platform (DSP),
+  might call the same API from an [=child navigable|iframe=].
+  Making The same API call from a frame
+  results in saving the [=intermediary site=] identity with the impression.
+
+</div>
 
 <xmp class=idl>
 dictionary PrivateAttributionImpressionOptions {
@@ -1800,6 +1823,7 @@ urlPrefix: https://html.spec.whatwg.org/; spec: html; type: dfn
     text: scheme-and-host
     text: site
     text: top-level origin; url: #concept-environment-top-level-origin
+    text: iframe; url: #child-navigable
 urlPrefix: https://infra.spec.whatwg.org/; spec: infra; type: dfn;
     text: set; url: #sets
     text: string

--- a/api.bs
+++ b/api.bs
@@ -1090,25 +1090,6 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
       </dl>
 
-
-To <dfn>fill a histogram with last-touch attribution</dfn>, given a [=set=] of
-  [=impressions=] |matchedImpressions|, an integer |histogramSize|, and an integer |value|:
-
-1.  [=Assert=]: |matchedImpressions| is [=set/is empty|not empty=].
-
-1.  Let |impression| be the value in |matchedImpressions| with the most recent
-    [=impression/timestamp=].
-
-1.  Let |histogram| be the result of invoking [=create an all-zero histogram=]
-    with |histogramSize|.
-
-1.  Let |index| be |impression|'s [=impression/histogram index=].
-
-1.  If |index| is less than |histogram|'s [=list/size=], set |histogram|[|index|] to |value|.
-
-1.  Return |histogram|.
-
-
 To <dfn>create an all-zero histogram</dfn>, given an integer |size|:
 
 1.  Return a [=list=] of [=list/size=] |size|, whose [=list/items=] are all 0.
@@ -1145,6 +1126,26 @@ To perform <dfn>common matching logic</dfn>, given
     1.  [=set/Append=] |impression| to |matching|.
 
 1.  Return |matching|.
+
+
+#### Last-Touch Attribution #### {#last-touch-attribution}
+
+To <dfn>fill a histogram with last-touch attribution</dfn>, given a [=set=] of
+  [=impressions=] |matchedImpressions|, an integer |histogramSize|, and an integer |value|:
+
+1.  [=Assert=]: |matchedImpressions| is [=set/is empty|not empty=].
+
+1.  Let |impression| be the value in |matchedImpressions| with the most recent
+    [=impression/timestamp=].
+
+1.  Let |histogram| be the result of invoking [=create an all-zero histogram=]
+    with |histogramSize|.
+
+1.  Let |index| be |impression|'s [=impression/histogram index=].
+
+1.  If |index| is less than |histogram|'s [=list/size=], set |histogram|[|index|] to |value|.
+
+1.  Return |histogram|.
 
 
 ## User Control and Visibility ## {#user-control}

--- a/api.bs
+++ b/api.bs
@@ -1071,7 +1071,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
 1.  Switch on |options|.{{PrivateAttributionConversionOptions/logic}}:
       <dl class="switch">
-      : "`last-touch`"
+      : <a enum-value for=PrivateAttributionLogic>"last-touch"</a>
       :: Return the result of [=fill a histogram with last-touch attribution=] with |matchedImpressions|,
         |options|.{{PrivateAttributionConversionOptions/histogramSize}}, and
         |options|.{{PrivateAttributionConversionOptions/value}}.
@@ -1230,8 +1230,8 @@ by either MPC operator.
 
 ### Prio and DAP ### {#prio}
 
-The "dap-12-histogram" aggregation method
-uses Prio [[PRIO]]
+The <a enum-value for=PrivateAttributionProtocol>"dap-12-histogram"</a>
+aggregation method uses Prio [[PRIO]]
 and the Distributed Aggregation Protocol (DAP) [[DAP]].
 Specifically, this aggregation method uses
 the Prio3L1BoundSum instantiation [[PRIO-L1]]

--- a/api.bs
+++ b/api.bs
@@ -276,11 +276,11 @@ A conversion value might also be split between multiple impressions
 to split credit,
 though this capability is not presently supported in the API.
 
-<!-- TODO: This list seems like a non sequitur -->
+<!-- TODO
 * Compatibility with privacy-preserving aggregation services
 * Flexibility to assign buckets
 * As histogram size increases, noise becomes a problem
-
+-->
 
 # Overview of Operation # {#overview}
 

--- a/api.bs
+++ b/api.bs
@@ -797,16 +797,16 @@ using just the [=host=] part of the tuple.
 </p>
 
 To <dfn>parse a site</dfn>,
-returning either |site| or failure,
+returning either [=site=] or failure,
 given a [=string=] |input|,
 run these steps:
 
-1.  Assign |host| to the value returned by invoking [=host parser=],
+1.  Let |host| be the value returned by invoking [=host parser=],
     passing |input|.
 
 1.  If |host| is failure, return failure.
 
-1.  Assign |site| to the value returned by [=registrable domain|obtain a registrable domain=],
+1.  Let |site| be the value returned by [=registrable domain|obtain a registrable domain=],
     passing |host|.
 
 1.  If |site| is null, return failure.

--- a/api.bs
+++ b/api.bs
@@ -597,34 +597,91 @@ If there is no match, or if [[#dp|differential privacy]] disallows
 reporting the attribution, the returned conversion report will not
 contribute to the histogram, i.e., will be uniformly zero.
 
-<pre>
-navigator.privateAttribution.measureConversion({
-  // name of the aggregation service
-  aggregationService: serviceUrl,
+<div class=example id=ex-measure-conversion>
+  A site that observes a [=conversion=]
+  might choose to request the measurement
+  of the effect of different [=impression store|stored=] [=impressions=].
 
-  // the number of buckets in the histogram
-  histogramSize: 20,
-  // the amount of privacy budget to use
-  epsilon: 1,
+  To request the creation of an encrypted measurement,
+  the site invokes the {{PrivateAttribution/measureConversion()}} method.
 
-  // the attribution logic to use
-  logic: "last-touch",
-  // the value to assign to the histogram index of the impression
-  value: 3,
-  // the maximum value which can be generated across all reports included in the aggregation
-  // used together with epsilon to calibrate the differential privacy budget to use
-  maxValue: 5,
+  This function takes four different types of input:
 
-  // only consider impressions within the last N days
-  lookbackDays: 30,
-  // an optional filter to restrict the set of ads that can be attributed
-  filterData: 2,
-  // an optional set of sites where impressions might have been registered
-  impressionSites: ["publisher.example"],
-  // an optional set of sites which called the saveImpression API
-  intermediarySites: ["ad-tech.example"],
-});
-</pre>
+  1.  The selected aggregation service,
+      which is identified using a URL.
+      The <a href=#ex-find-service>example process for selecting an aggregation service</a>
+      shows how to select a service that the browser supports.
+
+      <xmp highlight=js>
+        const serviceDetails = {
+          aggregationService: serviceUrl,
+        };
+      </xmp>
+
+  1.  Details of the aggregated measurement.
+      These values will be consistent for all invocations of the API
+      across multiple browsers.
+      This includes the size of the histogram
+      and the amount of [=privacy budget=] that might have been expended.
+
+      <xmp highlight=js>
+        const aggregatedMeasurementDetails = {
+          histogramSize: 20,
+          epsilon: 1,
+        };
+      </xmp>
+
+  1.  A set of attributes,
+      all <span class=allow-2119>optional</span>,
+      that select the [=impressions=] to consider.
+      This includes how old impressions can be
+      ({{PrivateAttributionConversionOptions/lookbackDays}}),
+      the [=impression sites=] that might have saved impressions
+      ({{PrivateAttributionConversionOptions/impressionSites}}),
+      the [=intermediary sites=] that might have saved impressions
+      ({{PrivateAttributionConversionOptions/intermediarySites}}),
+      and the choice of {{PrivateAttributionConversionOptions/filterData}}.
+
+      <xmp highlight=js>
+        const selectionDetails = {
+          lookbackDays: 14,
+          impressionSites: ["publisher.example", "other.example"],
+          intermediarySites: ["ad-tech.example"],
+          filterData: 2,
+        };
+      </xmp>
+
+  1.  The choice of [=attribution logic=]
+      that the browser will apply,
+      plus any parameters that the logic needs.
+
+      <xmp highlight=js>
+        const attributionDetails = {
+          logic: "last-touch",
+          value: 3,
+          maxValue: 7,
+        };
+      </xmp>
+
+  Once these values are decided,
+  the site invokes the API to obtain an encrypted [=conversion report=].
+
+  <xmp highlight=js>
+    const measurement = await navigator.privateAttribution.measureConversion({
+      ...serviceDetails,
+      ...aggregatedMeasurementDetails,
+      ...selectionDetails,
+      ...attributionDetails,
+    });
+    sendReportToServer(measurement.report);
+  </xmp>
+
+  This [=conversion report|report=] can be collected,
+  along with other reports from this browser and other browsers.
+  Collected reports can then all be submitted to an [=aggregation service=]
+  to obtain an [[#histograms|aggregate histogram]].
+
+</div>
 
 <xmp class=idl>
 dictionary PrivateAttributionConversionOptions {
@@ -633,14 +690,14 @@ dictionary PrivateAttributionConversionOptions {
 
   required unsigned long histogramSize;
 
-  PrivateAttributionLogic logic = "last-touch";
-  unsigned long value = 1;
-  unsigned long maxValue = 1;
-
   unsigned long lookbackDays;
   unsigned long filterData;
   sequence<DOMString> impressionSites = [];
   sequence<DOMString> intermediarySites = [];
+
+  PrivateAttributionLogic logic = "last-touch";
+  unsigned long value = 1;
+  unsigned long maxValue = 1;
 };
 
 dictionary PrivateAttributionConversionResult {
@@ -665,6 +722,18 @@ The arguments to <a method for=PrivateAttribution>measureConversion()</a> are as
   <dd>The amount of [=privacy budget=] to expend on this [=conversion report=].</dd>
   <dt><dfn>histogramSize</dfn></dt>
   <dd>The number of histogram buckets to use in the [=conversion report=].</dd>
+  <dt><dfn>lookbackDays</dfn></dt>
+  <dd>A positive integer number of days. Only impressions occurring within the past `lookbackDays` may match this [=conversion=]. If omitted, it is equivalent to an [=implementation-defined=] maximum.</dd>
+  <dt><dfn>filterData</dfn></dt>
+  <dd>Only [=impressions=] having a filterData value matching this value will be eligible to match this [=conversion=].</dd>
+  <dt><dfn>impressionSites</dfn></dt>
+  <dd>A [=set=] of impression sites. Only [=impressions=] recorded where the [=impression site=] is in this set are eligible to match this [=conversion=].</dd>
+  <dt><dfn>intermediarySites</dfn></dt>
+  <dd>
+    A [=set=] of sites which called the <a method for=PrivateAttribution>saveImpression()</a> API.
+    Only [=impressions=] recorded by scripts originating from one of the [=intermediary sites=]
+    are eligible to match this [=conversion=].
+  </dd>
   <dt><dfn>logic</dfn></dt>
   <dd>
     A selection from <a enum>PrivateAttributionLogic</a> indicating the
@@ -682,18 +751,6 @@ The arguments to <a method for=PrivateAttribution>measureConversion()</a> are as
     Together with epsilon, this is used to calibrate the distribution of random noise that
     will be added to the outcome. It is also used to determine the amount of [=privacy budget=]
     to expend on this [=conversion report=].
-  </dd>
-  <dt><dfn>lookbackDays</dfn></dt>
-  <dd>A positive integer number of days. Only impressions occurring within the past `lookbackDays` may match this [=conversion=]. If omitted, it is equivalent to an [=implementation-defined=] maximum.</dd>
-  <dt><dfn>filterData</dfn></dt>
-  <dd>Only [=impressions=] having a filterData value matching this value will be eligible to match this [=conversion=].</dd>
-  <dt><dfn>impressionSites</dfn></dt>
-  <dd>A [=set=] of impression sites. Only [=impressions=] recorded where the [=impression site=] is in this set are eligible to match this [=conversion=].</dd>
-  <dt><dfn>intermediarySites</dfn></dt>
-  <dd>
-    A [=set=] of sites which called the <a method for=PrivateAttribution>saveImpression()</a> API.
-    Only [=impressions=] recorded by scripts originating from one of the [=intermediary sites=]
-    are eligible to match this [=conversion=].
   </dd>
 </dl>
 

--- a/api.bs
+++ b/api.bs
@@ -557,7 +557,7 @@ that the [=user agent=] record an [=impression=] in the [=impression store=].
   Alternatively, an intermediary,
   such as a Supply-Side Platform (SSP) or Demand-Side Platform (DSP),
   might call the same API from an [=child navigable|iframe=].
-  Making The same API call from a frame
+  Making the same API call from a frame
   results in saving the [=intermediary site=] identity with the impression.
 
 </div>

--- a/api.bs
+++ b/api.bs
@@ -1118,21 +1118,37 @@ and given <a dictionary lt=PrivateAttributionImpressionOptions>|options|</a>:
 <!-- TODO: Check the {{PermissionPolicy/save-impression}} policy. -->
 
 1.  Collect the implicit API inputs from |settings|:
-    1.  The timestamp is set to |settings|'s [=environment settings object/current wall time=].
-    1.  The [=impression site=] is set to the result of
+    1.  Let |timestamp| be |settings|'s [=environment settings object/current wall time=].
+    1.  The [=impression site=] |site| is set to the result of
         [=obtain a site|obtaining a site=] from the [=top-level origin=].
-    1.  The [=intermediary site=] is set to
+    1.  The [=intermediary site=] |intermediarySite| is set to
         1.   a value of `undefined` if the [=origin=] is [=same site=]
              with the [=top-level origin=],
         1.   otherwise, the result of
              [=obtain a site|obtaining a site=] from the [=origin=].
 1.  Validate the page-supplied API inputs:
-    1. If |options|.{{PrivateAttributionImpressionOptions/lifetimeDays}} is 0,
+    1.  If |options|.{{PrivateAttributionImpressionOptions/lifetimeDays}} is 0,
         throw a {{RangeError}}.
-    1. Clamp |options|.{{PrivateAttributionImpressionOptions/lifetimeDays}} to
+    1.  Clamp |options|.{{PrivateAttributionImpressionOptions/lifetimeDays}} to
         the [=user agent=]'s upper limit.
-1.  If the Private Attribution API is [[#opt-out|enabled]], save the impression
-    to the [=impression store=].
+    1.  Let |conversionSite| be the result of invoking [=parse a site=]
+        with |options|.{{PrivateAttributionImpressionOptions/conversionSite}}.
+    1.  If |conversionSite| is failure, return {{SyntaxError}}.
+1.  If the Private Attribution API is [[#opt-out|disabled]], return.
+1.  Construct |impression| as a [=impression|saved impression=] comprising:
+    *   [=impression/Filter Data=] set to
+        |options|.{{PrivateAttributionImpressionOptions/filterData}}.
+    *   [=impression/Impression Site=] set to |site|.
+    *   [=impression/Intermediary Site=] set to |intermediarySite|.
+    *   [=impression/Conversion Sites=] set to a single element [=set=]
+        containing |conversionSite|.
+    *   [=impression/Timestamp=] set to |timestamp|.
+    *   [=impression/Lifetime=] set to
+        |options|.{{PrivateAttributionImpressionOptions/lifetimeDays}},
+        multiplied by a [=duration=] of one day.
+    *   [=impression/Histogram Index=] set to
+        |options|.{{PrivateAttributionImpressionOptions/histogramIndex}}.
+1.  Save |impression| to the [=impression store=].
 
 <p class=advisement><a method for=PrivateAttribution>saveImpression()</a>
 does not return a status indicating whether the impression was recorded.

--- a/api.bs
+++ b/api.bs
@@ -585,6 +585,15 @@ The arguments to <a method for=PrivateAttribution>saveImpression()</a> are as fo
     An optional piece of metadata associated with the impression. The value
     can be used to identify which impressions may receive attribution
     from a [=conversion=].
+    <p class=note>It is intentional that on the impression side this field
+    defaults to 0, while on
+    {{PrivateAttributionConversionOptions/filterData|the conversion side}} it is
+    an <span class=allow-2119>optional</span> field without a default: A default
+    on the impression side means that implementations do not need to use a bit
+    to represent potential absence of the field for each impression in the
+    [=impression store=], while optionality on the conversion side means that
+    there is a way to match any filter data, which would not be possible if
+    there were a default integer value.
   </dd>
   <dt><dfn>conversionSite</dfn></dt>
   <dd>
@@ -749,7 +758,7 @@ The arguments to <a method for=PrivateAttribution>measureConversion()</a> are as
   <dt><dfn>lookbackDays</dfn></dt>
   <dd>A positive integer number of days. Only impressions occurring within the past `lookbackDays` may match this [=conversion=]. If omitted, it is equivalent to an [=implementation-defined=] maximum.</dd>
   <dt><dfn>filterData</dfn></dt>
-  <dd>Only [=impressions=] having a [=impression/filter data=] value matching this value will be eligible to match this [=conversion=].</dd>
+  <dd>Only [=impressions=] having a [=impression/filter data=] value matching this value will be eligible to match this [=conversion=]. If omitted, all [=impression/filter data=] values will match.</dd>
   <dt><dfn>impressionSites</dfn></dt>
   <dd>A [=set=] of impression sites. Only [=impressions=] recorded where the [=impression site=] is in this set are eligible to match this [=conversion=].</dd>
   <dt><dfn>intermediarySites</dfn></dt>

--- a/api.bs
+++ b/api.bs
@@ -69,7 +69,7 @@ it would enable unwanted
 [[PRIVACY-PRINCIPLES#dfn-cross-context-recognition|cross-context recognition]],
 thereby enabling [[UNSANCTIONED-TRACKING|tracking]].
 
-This document avoids cross context recognition by ensuring that
+This document avoids cross-context recognition by ensuring that
 attribution information is aggregated using an [=aggregation service=].
 The aggregation service is trusted to compute an aggregate
 without revealing the values that each person contributes to that aggregate.
@@ -92,14 +92,14 @@ was the ability to obtain information about the effectiveness of advertising cam
 
 Web advertisers were able to measure key metrics like reach (how many people saw an ad),
 frequency (how often each person saw an ad),
-and [=conversions=] (how many people saw the ad then later took the action that the ad was supposed to motivate).
+and [=conversions=] (how many people who saw the ad then later took the action that the ad was supposed to motivate).
 In comparison, these measurements were far more timely and accurate than for any other medium.
 
 The cost of measurement performance was privacy.
 In order to produce accurate and comprehensive information,
 advertising businesses performed extensive tracking of the activity of all Web users.
 Each browser was given a tracking identifier,
-often using cookies that were lodged by cross-site content.
+often using cookies that were logged by cross-site content.
 Every action of interest was logged against this identifier,
 forming a comprehensive record of a person's online activities.
 
@@ -115,7 +115,7 @@ Any competitive edge gained by these entities--
 and the intermediaries that operate on their behalf--
 depends on having more comprehensive information about a potential audience.
 
-Over time, actions of interest expanded to include nearly every aspects of online activity.
+Over time, actions of interest expanded to include nearly every aspect of online activity.
 Methods were devised to correlate that information with activity outside of the Web.
 An energetic trade has formed,
 with multiple purveyors of personal information that is traded for various purposes.
@@ -271,20 +271,20 @@ which might be used to differentiate between different outcomes.
 The value that is allocated to impressions
 is called a <dfn>conversion value</dfn>.
 A higher conversion value might be used for larger purchases
-or any outcome that is more highly-valued.
+or any outcome that is more highly valued.
 A conversion value might also be split between multiple impressions
 to split credit,
 though this capability is not presently supported in the API.
 
+<!-- TODO: This list seems like a non sequitur -->
 * Compatibility with privacy-preserving aggregation services
 * Flexibility to assign buckets
-
 * As histogram size increases, noise becomes a problem
 
 
 # Overview of Operation # {#overview}
 
-The private attribution API provides aggregate information about the
+The Private Attribution API provides aggregate information about the
 association between two classes of events: [=impressions=] and [=conversions=].
 
 An [=impression=] is any action that an advertiser takes on any website.
@@ -346,7 +346,7 @@ The histogram created by the [=conversion report=] is constructed as follows:
     value is added to a histogram at the bucket that was specified at the time of the
     attributed impression. All other buckets are set to zero.
 
-The browser updates the privacy budget store to reflect the reported conversion.
+The browser updates the [=privacy budget store=] to reflect the reported conversion.
 
 The resulting histogram is prepared for aggregation according to the requirements
 of the chosen [=aggregation service=] and returned to the site.
@@ -365,7 +365,7 @@ Upon receiving a set of encrypted histograms from a site, the aggregation servic
     from the provided inputs
     and that there are enough conversion reports,
 
-2.  adds the histograms including sufficient [[#dp|noise]]
+2.  adds the histograms, including sufficient [[#dp|noise]],
     to produce a differentially-private aggregate histogram, and
 
 3.  returns the aggregate to the site.
@@ -511,7 +511,7 @@ The URL is passed as the {{PrivateAttributionConversionOptions/aggregationServic
 to <a method for=PrivateAttribution>measureConversion()</a> to select the identified aggregation service.
 
 The <dfn enum>PrivateAttributionProtocol</dfn> describes the submission protocol
-used by different [=aggregation services=].  This document defines two protocols:
+used by different [=aggregation services=]. This document defines two protocols:
 
 <dl dfn-for=PrivateAttributionProtocol dfn-type=enum-value>
   <dt><dfn>dap-12-histogram</dfn></dt>
@@ -582,7 +582,7 @@ The arguments to <a method for=PrivateAttribution>saveImpression()</a> are as fo
   </dd>
   <dt><dfn>filterData</dfn></dt>
   <dd>
-    An optional piece of metadata associated with the impression. The filterData
+    An optional piece of metadata associated with the impression. The value
     can be used to identify which impressions may receive attribution
     from a [=conversion=].
   </dd>
@@ -749,7 +749,7 @@ The arguments to <a method for=PrivateAttribution>measureConversion()</a> are as
   <dt><dfn>lookbackDays</dfn></dt>
   <dd>A positive integer number of days. Only impressions occurring within the past `lookbackDays` may match this [=conversion=]. If omitted, it is equivalent to an [=implementation-defined=] maximum.</dd>
   <dt><dfn>filterData</dfn></dt>
-  <dd>Only [=impressions=] having a filterData value matching this value will be eligible to match this [=conversion=].</dd>
+  <dd>Only [=impressions=] having a [=impression/filter data=] value matching this value will be eligible to match this [=conversion=].</dd>
   <dt><dfn>impressionSites</dfn></dt>
   <dd>A [=set=] of impression sites. Only [=impressions=] recorded where the [=impression site=] is in this set are eligible to match this [=conversion=].</dd>
   <dt><dfn>intermediarySites</dfn></dt>
@@ -807,7 +807,7 @@ to the expected kind of activity.
 <p class=note>Enabling permissions by default
 simplifies the task of integrating external services.
 
-<p class=note>Permissions policy provides only all-or-nothing control,
+<p class=note>Permissions policy provides only all-or-nothing control;
 it does not enable delegation of a portion of privacy budget.
 
 
@@ -841,7 +841,7 @@ The [=impression store=] is a [=set=] of [=impression|impressions=]:
 ### Maintenance ### {#impression-store-maintenance}
 
 The [=user agent=] should periodically use
-the timestamp and lifetime values
+the [=impression/timestamp=] and [=impression/lifetime=] values
 to identify and delete any [=impressions=] in the [=impression store=]
 that have expired.
 
@@ -963,6 +963,8 @@ To <dfn>save an impression</dfn>,
 given an [=environment settings object=] |settings|
 and given <a dictionary lt=PrivateAttributionImpressionOptions>|options|</a>:
 
+<!-- TODO: Check the {{PermissionPolicy/save-impression}} policy. -->
+
 1.  Collect the implicit API inputs from |settings|:
     1.  The timestamp is set to the [=current high resolution time=].
     1.  The [=impression site=] is set to the result of
@@ -977,7 +979,7 @@ and given <a dictionary lt=PrivateAttributionImpressionOptions>|options|</a>:
         throw a {{RangeError}}.
     1. Clamp |options|.{{PrivateAttributionImpressionOptions/lifetimeDays}} to
         the [=user agent=]'s upper limit.
-1.  If the private attribution API is [[#opt-out|enabled]], save the impression
+1.  If the Private Attribution API is [[#opt-out|enabled]], save the impression
     to the [=impression store=].
 
 <p class=advisement><a method for=PrivateAttribution>saveImpression()</a>
@@ -991,6 +993,8 @@ API is [[#opt-out|disabled]].
 To <dfn>measure a conversion</dfn>,
 given a [=environment settings object=] |settings|
 and <a dictionary lt=PrivateAttributionConversionOptions>|options|</a>:
+
+<!-- TODO: Check the {{PermissionPolicy/measure-conversion}} policy. -->
 
 1.  Collect the implicit API inputs from |settings|:
     1.  Let |now| be the [=current high resolution time=].
@@ -1010,7 +1014,7 @@ and <a dictionary lt=PrivateAttributionConversionOptions>|options|</a>:
     1. If |options|.{{PrivateAttributionConversionOptions/lookbackDays}} is 0,
         throw a {{RangeError}}.
 1.  Let |report| be an [=create an all-zero histogram|all-zero histogram=].
-1.  If the private attribution API is [[#opt-out|enabled]], set |report| to the
+1.  If the Private Attribution API is [[#opt-out|enabled]], set |report| to the
     result of [=do attribution and fill a histogram=] with |options|,
     |topLevelSite|, and |now|.
 1. Let |encryptedReport| be the result of encrypting |report|.
@@ -1033,7 +1037,7 @@ enum PrivateAttributionLogic {
 </xmp>
 
 Each attribution logic specifies a process for allocating values to histogram buckets,
-after the [=common matching logic=] is applied, and privacy budgeting occurs.
+after the [=common matching logic=] is applied and privacy budgeting occurs.
 
 
 To <dfn>do attribution and fill a histogram</dfn>, given
@@ -1100,7 +1104,7 @@ To <dfn>create an all-zero histogram</dfn>, given an integer |size|:
 ### Common Impression Matching Logic ### {#logic-matching}
 
 To perform <dfn>common matching logic</dfn>, given
-<a dictionary lt=PrivateAttributionConversionOptions>|options|</a>, |epoch|, and
+<a dictionary lt=PrivateAttributionConversionOptions>|options|</a>, [=epoch=] |epoch|, and
 [=moment=] |now|:
 
 1.  Let |matching| be an [=set/is empty|empty=] [=set=].
@@ -1144,7 +1148,7 @@ This mechanism may be a dedicated control
 for the Private Attribution API,
 or it may be a consolidated privacy control
 that applies to multiple features,
-including private attribution.
+including Private Attribution.
 Further, user agent developers should consider interaction
 of other privacy modes with the Private Attribution API.
 For example, attribution might be disabled in a private browsing mode,
@@ -1162,7 +1166,7 @@ if the user has opted out of collection of diagnostic data.
     * Histogram size
     * [=Conversion site=] for [=impressions=]
     * [=Impression site=] for [=conversions=]
-    * Ad IDs
+    * Histogram indexes
 
 # Aggregation # {#aggregation}
 
@@ -1203,7 +1207,7 @@ its reliance on client-provided proofs of correctness for inputs.
 This allows for very efficient MPC operation
 at a modest cost in the size of submissions to the system.
 
-An aggregation service that uses Multi-Party Computation (MPC)
+An aggregation service that uses MPC
 comprises two or more independent services
 that cooperate to compute a predefined function.
 
@@ -1320,7 +1324,7 @@ that is contributed.
 The [=individual differential privacy=] design of this API
 has three primary components:
 
-1.  User agents limit (using the privacy budget) the amount of information
+1.  User agents limit (using the [=privacy budget=]) the amount of information
     about [=impressions=] that leaves the device through [=conversion reports=].
     [[#dp-budget]] explores this in greater depth.
 
@@ -1351,9 +1355,9 @@ that is the combination of three values:
     That is, an instance of a user agent,
     as used by a single person.
 
-2.  The [=site=] that requests information about impressions.
+2.  The [=site=] that requests information about [=impressions=] (the [=conversion site=]).
 
-    <p class=note>The sites that register impressions
+    <p class=note>The sites that register impressions (the [=impression site=])
     are not considered.
     Those sites do not receive information from this system directly.
 
@@ -1431,7 +1435,7 @@ and its duration is one week (7 days), where a <dfn>day</dfn> is 86400 seconds.
 This budget applies to the [=impressions=]
 that are registered with the [=user agent=]
 and later queried,
-not conversions.
+not [=conversions=].
 
 From the perspective of the analysis [[PPA-DP]]
 each [=epoch=] of [=impressions=] forms a separate database.
@@ -1454,7 +1458,7 @@ at any point in time,
 while keeping the overall rate of privacy loss low.
 However, a longer interval means that it is easier to
 exhaust a privacy budget completely,
-yield no information until the next refresh.
+yielding no information until the next refresh.
 
 The decision to set the [=epoch=] duration to a week is largely arbitrary.
 One week is expected to be enough to allow sites
@@ -1468,7 +1472,7 @@ changes that might occur days or weeks in the future.
 ## Privacy Budgets ## {#dp-budget}
 
 Browsers maintain <dfn>privacy budgets</dfn>,
-which is a means of limiting the amount of privacy loss.
+which are a means of limiting the amount of privacy loss.
 
 This specification uses an individual form
 of (&epsilon;, &delta;)-differential privacy as its basis.
@@ -1481,13 +1485,13 @@ managing privacy budgets.
 
 Each [=conversion report=] that is requested specifies an &epsilon; value
 that represents the amount of privacy budget
-that the report consumes and a max on the value that can be returned in the
+that the report consumes and a maximum on the value that can be returned in the
 conversion report.
 
 
 ### Privacy Budget Deduction ### {#dp-deduction}
 
-When searching for impressions for the conversion report,
+When searching for [=impressions=] for the conversion report,
 the user agent deducts the specified &epsilon; value from
 the budget for the [=privacy budget epoch=] in which those impressions were saved.
 If the privacy budget for that [=privacy budget epoch|epoch=] is not sufficient,
@@ -1509,9 +1513,9 @@ The details of how to [=deduct privacy budget=] is given below ... WIP
 
     A [=conversion report=] might be requested at the time marked with "now".
     That conversion report selects impressions marked with black circles,
-    corresponding to impressions from Site B, C, and E.
+    corresponding to impressions from Sites B, C, and E.
 
-    As a result, privacy budgets for the querying site is deducted
+    As a result, privacy budget for the querying site is deducted
     from [=privacy budget epoch|epochs=] 1, 3, 4, and 5.
     No impressions were recorded for epoch 2,
     so no budget is deducted from that epoch.
@@ -1581,7 +1585,7 @@ of harmful information flow through the impression store:
 
 *   Websites cannot read from the impression store.
     Information from the impression store
-    is released only via encrypted conversion reports.
+    is released only via encrypted [=conversion reports=].
     [[#dp|Differential privacy]], provided by a combination
     of functionality in the user agent
     and in the [=aggregation service=],
@@ -1611,7 +1615,7 @@ A site calling the APIs must not be able to learn:
 *   Whether the [=conversion report=] reflects a non-zero
     [=conversion value=].
 *   Which <a dict-member for=PrivateAttributionImpressionOptions>histogramIndex</a>
-    is assigned the conversion value.
+    is assigned the [=conversion value=].
 
 Note that explicit return values or thrown exceptions
 are not the only way that a site can learn from
@@ -1633,7 +1637,7 @@ Strategies to prevent leakage include:
 *   Avoiding conditional logic. For example,
     <a method for=PrivateAttribution>measureConversion()</a>
     should always go through the full process of constructing
-    a conversion report, even when the conversion value to be
+    a conversion report, even when the [=conversion value=] to be
     reported is zero.
 
 
@@ -1644,7 +1648,7 @@ security of aggregation services is quite important
 to the overall security of the Private Attribution mechanism.
 [=Conversion reports=]
 produced by <a method for=PrivateAttribution>measureConversion()</a>
-are encrypted to cryptographic key(s) of the aggregation service.
+are encrypted using cryptographic key(s) of the aggregation service.
 Thus, much of the potential for disclosure
 of the information contained in these reports
 depends on the details of the aggregation service.
@@ -1685,8 +1689,8 @@ is a particular concern with the Private Attribution API,
 because impressions are stored only on the device.
 It is not possible to apply server-side intelligence
 to identify fraudulent impressions and exclude them
-from attribution. Conversely, even though conversion
-reports are encrypted, because the reports are sent
+from attribution. Conversely, even though [=conversion
+reports=] are encrypted, because the reports are sent
 to a server, the server can make a determination that
 the conversion is likely fraudulent and exclude it from
 aggregation.
@@ -1694,7 +1698,7 @@ aggregation.
 An important mitigation against malicious use
 of the Private Attribution APIs is the explicit specification
 of eligible conversion sites when registering an impression,
-and of eligible impression sites and ad IDs
+and of eligible impression sites and histogram indexes
 when registering a conversion.
 This prevents impressions on arbitrary malicious sites
 from interfering with attribution to the intended set
@@ -1733,17 +1737,17 @@ with a limited set of related impression candidates,
 it is important to consider how the API might be misused
 for larger-scale data collection.
 The requirement that impressions enumerate
-the possible conversion sites (and vice-versa)
+the possible [=conversion sites=] (and vice-versa)
 has an important role in preventing misuse of the API
 for mass data collection, and in making attempts
 at such misuse more visible.
 
 <p class=issue>
 It is unclear whether the [=privacy budget store=] should be cleared whenever
-the impression store is cleared. On one hand, it contains information about
-browsing activity, so is desirable to include it when clearing browsing activity.
+the [=impression store=] is cleared. On one hand, it contains information about
+browsing activity, so it is desirable to include it when clearing browsing activity.
 On the other hand, it is only possible to strictly adhere to the requirements of
-the differential privacy mechanism, if information about a fully- or partially-
+the differential privacy mechanism if information about a fully- or partially-
 depleted privacy budget is maintained until that budget is no longer relevant
 (i.e. the end of the [=privacy budget epoch=]).
 
@@ -1764,11 +1768,11 @@ and to prevent discrimination
 against users who choose to disable the Private Attribution API,
 sites must not be able to detect that the API is disabled.
 Specifically, all calls to the Private Attribution API
-that are otherwise valid,
+that are otherwise valid
 must complete successfully, even when the API is disabled.
 The only difference in behavior
-is that conversion reports returned when the API is disabled
-will never report any conversion value.
+is that [=conversion reports=] returned when the API is disabled
+will never report any [=conversion value=].
 Because the reports are encrypted,
 this difference cannot be detected
 by the site receiving the conversion report.
@@ -1788,7 +1792,7 @@ which implies some risk of that identifying information
 becoming available to the site that receives that report.
 The following measures mitigate this risk:
 
-*   The impression store cannot be read directly.
+*   The [=impression store=] cannot be read directly.
     Thus, identifiers are only usable for tracking
     to the extent information about them
     is revealed in [=conversion reports=].

--- a/api.bs
+++ b/api.bs
@@ -776,6 +776,50 @@ to clear stored browsing data (history, cookies, etc.)
 be extended to cover the impression store.
 
 
+### Site Names ### {#site-name-algorithm}
+
+The [=impression store=] saves information
+about three types of [=site=]:
+the [=impression/impression site=],
+an optional [=impression/intermediary site=],
+and a [=set=] of [=impression/conversion sites=].
+
+These [=sites=] MUST all be in [=scheme-and-host=] form,
+with a [=scheme=] of "`https`".
+This means that a simple string serialization of a [=host=]
+is sufficient to identify the site.
+The API is therefore able to use a simple [=string=]
+to represent [=sites=].
+
+<p class=note>
+It is also possible for an implementation to internally represent sites
+using just the [=host=] part of the tuple.
+</p>
+
+To <dfn>parse a site</dfn>,
+returning either |site| or failure,
+given a [=string=] |input|,
+run these steps:
+
+1.  Assign |host| to the value returned by invoking [=host parser=],
+    passing |input|.
+
+1.  If |host| is failure, return failure.
+
+1.  Assign |site| to the value returned by [=registrable domain|obtain a registrable domain=],
+    passing |host|.
+
+1.  If |site| is null, return failure.
+
+1.  Return a [=scheme-and-host=] tuple of ("`https`", |site|).
+
+<p class=note>
+This algorithm successfully produces a site from strings
+that contain more [=domain labels=] than the [=registrable domain=].
+For example, "`extra.example.com`" is parsed as "`example.com`".
+</p>
+
+
 ## Privacy Budget Store ## {#s-privacy-budget-store}
 
 <!--
@@ -964,6 +1008,7 @@ To <dfn>create an all-zero histogram</dfn>, given an integer |size|:
 
 1.  Return a [=list=] of [=list/size=] |size|, whose [=list/items=] are all 0.
 
+
 ### Common Impression Matching Logic ### {#logic-matching}
 
 To perform <dfn>common matching logic</dfn>, given
@@ -995,6 +1040,7 @@ To perform <dfn>common matching logic</dfn>, given
     1.  [=set/Append=] |impression| to |matching|.
 
 1.  Return |matching|.
+
 
 ## User Control and Visibility ## {#user-control}
 
@@ -1688,15 +1734,23 @@ The privacy architecture is courtesy of the authors of [[PPA-DP]].
 
 <pre class=anchors>
 urlPrefix: https://html.spec.whatwg.org/; spec: html; type: dfn
+    text: host; url: #concept-origin-host
     text: obtain a site
     text: origin; url: #concept-origin
     text: relevant settings object
     text: same site
+    text: scheme; url: #concept-origin-scheme
+    text: scheme-and-host
     text: site
     text: top-level origin; url: #concept-environment-top-level-origin
 urlPrefix: https://infra.spec.whatwg.org/; spec: infra; type: dfn;
-    text: user agent
     text: set; url: #sets
+    text: string
+    text: user agent
+urlPrefix: https://url.spec.whatwg.org/; spec: url; type: dfn;
+    text: domain label
+    text: host parser; url: #concept-host-parser
+    text: registrable domain; url: #host-registrable-domain
 </pre>
 <pre class=biblio>
 {

--- a/api.bs
+++ b/api.bs
@@ -725,8 +725,8 @@ dictionary PrivateAttributionConversionOptions {
 
   unsigned long lookbackDays;
   unsigned long filterData;
-  sequence<DOMString> impressionSites = [];
-  sequence<DOMString> intermediarySites = [];
+  sequence<USVString> impressionSites = [];
+  sequence<USVString> intermediarySites = [];
 
   PrivateAttributionLogic logic = "last-touch";
   unsigned long value = 1;


### PR DESCRIPTION
This is built on https://github.com/w3c/ppa/pull/104.

This contributes to https://github.com/w3c/ppa/issues/102 by laying some of the ground work regarding
sites.  It should now be possible to "parse a site" when preparing to
invoke the matching logic.  That comes next.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/pull/106.html" title="Last updated on Apr 24, 2025, 6:18 AM UTC (7f62ed2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/106/eba7f55...7f62ed2.html" title="Last updated on Apr 24, 2025, 6:18 AM UTC (7f62ed2)">Diff</a>