### PR TITLE
Fix erroneous usage of `some` method in example code

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -461,9 +461,9 @@ and impressions are not scoped to a single aggregation service.
     "https://aggregator.example/dap",
     "https://example.com/aggregator",
   ];
-  const supportedServices = navigator.privateAttribution?.aggregationServices;
+  const supportedServices = navigator.privateAttribution?.aggregationServices?.values();
   const serviceUrl = preferredServices.find(preference => {
-    supportedServices?.some(svc => svc.url === preference)
+    supportedServices.some(svc => svc.url === preference)
   })?.url;
   </xmp>
 


### PR DESCRIPTION
The [`PrivateAttributionAggregationServices` interface](https://w3c.github.io/ppa/#privateattributionaggregationservices) is [`setlike`](https://webidl.spec.whatwg.org/#js-setlike), so in order to call `some` we must first call `values`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/112.html" title="Last updated on Mar 3, 2025, 5:14 PM UTC (f6ded4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/112/60a439f...apasel422:f6ded4d.html" title="Last updated on Mar 3, 2025, 5:14 PM UTC (f6ded4d)">Diff</a>