### PR TITLE
Define epoch

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -911,8 +911,7 @@ A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items
 </dl>
 
 To <dfn>deduct privacy budget</dfn>
-given an [=environment settings object=] |settings|,
-a [=privacy budget key=] |key|,
+given a [=privacy budget key=] |key|,
 [=float=] |epsilon|,
 integer |sensitivity|,
 and integer |globalSensitivity|:
@@ -944,8 +943,7 @@ The <dfn>epoch start store</dfn> is a [=map=] keyed by [=site=]
 with values that are [=moments=].
 
 To <dfn>get the current epoch</dfn>
-given an [=environment settings object=] |settings|,
-a [=site=] |site|,
+given a [=site=] |site|,
 and [=moment=] |now|:
 
 1.  Let |period| be the [=duration=] of one [=epoch=].
@@ -1945,8 +1943,6 @@ When clearing site data,
 but retaining browsing history,
 a [=user agent=] can [=map/set=] the value
 in the [=privacy budget store=] to 0 for all [=epochs=]
-up to the [=get the current epoch|current epoch=],
-starting from the [=get the starting epoch for attribution|earliest available epoch=]
 for all affected [=sites=].
 
 

--- a/api.bs
+++ b/api.bs
@@ -948,7 +948,7 @@ given an [=environment settings object=] |settings|,
 a [=site=] |site|,
 and [=moment=] |now|:
 
-1.  Let |period| be the [=duration=] of one [=epoch=] (i.e., 86400 seconds).
+1.  Let |period| be the [=duration=] of one [=epoch=].
 
 1.  If the [=epoch start store=] does not [=map/contain=] |site|, [=map/set=]
     its value to |now|, minus a [=duration=]
@@ -994,7 +994,7 @@ updating the [=last browsing history clear=] can be skipped if:
 
 *   All interactions that are cleared are with [=sites=]
     that have other uncleared interactions.
-*   All cleared interactions occuring during [=epochs=]
+*   All cleared interactions occurring during [=epochs=]
     where other interactions with the same [=site=] were retained.
 *   All affected [=sites=] have a value in the [=epoch start store=].
 
@@ -1003,7 +1003,7 @@ the [=last browsing history clear=] does not need to be updated.
 Instead, the [=privacy budget store=] must be updated
 by [=map/set|setting=] a value of 0
 for all [=privacy budget key=] combinations that can be formed
-from every affected [=sites=] and [=epochs=].
+from every affected [=site=] and [=epoch=].
 
 <p class=note>
 This optimization relies on the [=user agent=]
@@ -1030,12 +1030,12 @@ given [=site=] site:
         This use of [=get the current epoch=]
         can return a negative value.
         This is because the value in [=epoch start store=]
-        is likely to be set to a time be after history was last cleared.
+        is likely to be set to a time after history was last cleared.
 
     1.  Set |clearEpoch| to |clearEpoch| + 2.
 
         <p class=note>
-        Adding <em>two</em> is necessary to that the [=epoch=]
+        Adding <em>two</em> is necessary so that the [=epoch=]
         does not overlap with an [=epoch=]
         before browsing history--
         and the [=epoch start store=]--
@@ -1825,7 +1825,7 @@ In that case, if the API is re-enabled,
 there is no way to determine what budget was expended
 prior to the API being [[#opt-out|disabled]].
 In that case, a [=user agent=] can update
-the value [=last browsing history clear=]
+the value of [=last browsing history clear=]
 to ensure that [=privacy budgets=] are not inadvertently exceeded.
 
 
@@ -1865,7 +1865,7 @@ for a period between one and two [=epochs=]
 from the point that browsing history is discarded.
 Otherwise, a [=site=] that expends its budget
 immediately prior to the clearing of history
-would be able to learn more through API
+would be able to learn more through the API
 than it could without the clearing of state.
 
 <p class=note>
@@ -1879,21 +1879,21 @@ which cannot overlap with any [=epoch=] that might have been defined
 before history was cleared.
 
 A [=user agent=] remembers when history was last cleared
-in the [=last browsing history clear=] variable.
+in the [=last browsing history clear=] value.
 This is used to prevent [=privacy budget|budget=] expenditure
 until it is guaranteed that a [=site=] cannot exceed
 the [=user agent=]-chosen maximum allowed [=privacy budget=].
 
 The [=get the starting epoch for attribution=] algorithm
 ensures that an [=impression site=]
-cannot make queries [=impressions=] from any [=epoch=]
+cannot query [=impressions=] from any [=epoch=]
 that starts within one [=epoch=] [=duration=]
 from when state is cleared.
 
 
 ### Clearing Impressions ### {#removing-impressions}
 
-A mechanism must be provided to clear the impression store.
+A mechanism must be provided to clear the [=impression store=].
 For example, the impression store could be cleared
 upon activation of the control that
 [[#opt-out|disables]] the Private Attribution API.

--- a/api.bs
+++ b/api.bs
@@ -958,7 +958,7 @@ and [=moment=] |now|:
 1.  Let |start| be the result of [=map/get|getting the value=] of |site|
     from the [=epoch start store=].
 
-1.  Let |elapsed| be |now| - |start| / |period|.
+1.  Let |elapsed| be (|now| - |start|) / |period|.
 
 1.  Return |elapsed| as an integer, rounded towards negative Infinity.
 

--- a/api.bs
+++ b/api.bs
@@ -828,6 +828,10 @@ The <dfn>impression store</dfn> is used by the <a method
 for=PrivateAttribution>measureConversion()</a> method to find matching
 [=impressions=].
 
+<p class=note>
+Though this API enables the storage of data by sites,
+this does not use a [=storage key=].
+
 
 ### Contents ### {#impression-store-contents}
 
@@ -883,6 +887,12 @@ The [=privacy budget store=] records the state
 of the per-[=site=] [=privacy budgets=].
 It is updated by [=deduct privacy budget=].
 
+<p class=note>
+Like the [=impression store=],
+the [=privacy budget store=] does not use a [=storage key=].
+Additionally, the [=privacy budget store=] has some additional constraints
+on how information is cleared.
+
 <p class=issue>
 The [=safety limits=] need to be described in more detail.
 Some references to clearing
@@ -919,6 +929,52 @@ To <dfn>deduct privacy budget</dfn> given a [=privacy budget key=] |key|,
 1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=] to |newValue|.
 
 1.  Return whether |newValue| is greater than or equal to 0.
+
+
+### Clearing ### {#budget-store-clearing}
+
+A [=user agent=] might present the option to clear storage.
+These exist for two reasons:
+
+*   Privacy toward sites,
+    so that the sites cannot recognize the [=user=] in future interactions.
+    (that is, to [=same site recognition=])
+
+*   Removing traces of activity locally,
+    so that other users of a computer
+    cannot access browsing history.
+
+Clearing privacy budget state has an adverse effect on privacy toward sites,
+because it might allow sites to gain more information
+through attribution.
+Retaining any per-site information
+necessary to prevent privacy loss toward sites
+leaves information about visits to sites
+for other users of a computer to discover.
+
+To this end, [=user agents=] can both
+remove per-site information
+and globally disable the attribution API.
+Attribution needs to be disabled for one [=epoch=]
+from the point that state is discarded.
+Otherwise, site that expends its budget
+immediately prior to the clearing of state
+would be able to learn more through th eAPI
+than it could without the clearing of state.
+
+This does not apply if only some interactions with a site are cleared,
+such as if local storage of activity over a set time window are removed.
+This only applies if all interactions with a site
+need to be removed.
+
+A [=user agent=] therefore has to remember when state was last cleared,
+preventing budget expenditure until that time elapses.
+A site that has an [=epoch=] that starts within
+that offers selective deletion of history,
+such as the removal of state for a single site,
+could partition this value so that other sites remain unaffected.
+However, this cannot use too many partitions,
+or the choice of partition will correlate strongly with site identity.
 
 
 
@@ -1799,6 +1855,8 @@ urlPrefix: https://html.spec.whatwg.org/; spec: html; type: dfn
 urlPrefix: https://infra.spec.whatwg.org/; spec: infra; type: dfn;
     text: user agent
     text: set; url: #sets
+urlPrefix: https://storage.spec.whatwg.org/; spec: storage; type: dfn;
+    text: storage key
 </pre>
 <pre class=biblio>
 {

--- a/api.bs
+++ b/api.bs
@@ -864,34 +864,43 @@ excludes expired [=impressions=] from [=attribution=]. However, the
 [=user agent=] should not retain expired [=impressions=] indefinitely.
 
 
-### Clearing ### {#impression-store-clearing}
+### Clearing Impression State ### {#impression-store-clearing}
 
 A mechanism must be provided to clear the impression store.
 For example, the impression store could be cleared
 upon activation of the control that
 [[#opt-out|disables]] the Private Attribution API.
+
 It is recommended that any mechanism a user agent provides
-to clear stored browsing data (history, cookies, etc.)
+to clear stored data (history, cookies, etc.)
 be extended to cover the impression store.
+[[#clear-budget-store]] provides more detailed information
+on the clearing of stored data.
 
 
-## Privacy Budget Store ## {#s-privacy-budget-store}
+## State For Privacy Budget Management ## {#privacy-state}
 
-<!--
-Added this here for symmetry with the impression store and with the philosophy
-that "just tell me how to implement" goes in the API section. But I'd also be
-fine with putting this in the DP section.
--->
+[=User agents=] maintain three pieces of state
+that are used to manage the expenditure of [=privacy budgets=]:
 
-The [=privacy budget store=] records the state
-of the per-[=site=] [=privacy budgets=].
-It is updated by [=deduct privacy budget=].
+*   The [=privacy budget store=] records the state
+    of the per-[=site=] and per-[=epoch=] [=privacy budgets=].
+    It is updated by [=deduct privacy budget=].
+
+*   The [=epoch start store=] records when each [=epoch=] starts
+    for [=impression sites=].
+    This store is initialized as a side effect
+    of invoking <a method for=PrivateAttribution>saveImpression()</a>.
+
+*   A singleton [=last browsing history clear=] value
+    that tracks when the browsing activity for a [=site=] was last cleared.
 
 <p class=note>
 Like the [=impression store=],
 the [=privacy budget store=] does not use a [=storage key=].
-Additionally, the [=privacy budget store=] has some additional constraints
-on how information is cleared.
+These stores have some additional constraints
+on how information is cleared;
+see [[#clear-budget-store]] for details.
 
 <p class=issue>
 The [=safety limits=] need to be described in more detail.
@@ -899,6 +908,11 @@ Some references to clearing
 the [=impression store=] may need to be
 updated to refer to the [=privacy budget store=] as well.
 
+
+### Privacy Budget Store ### {#s-privacy-budget-store}
+
+The <dfn>privacy budget store</dfn> is a [=map=] whose keys are
+[=privacy budget keys=] and whose values are [=floats=].
 
 A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items:
 
@@ -910,14 +924,15 @@ A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items
 
 </dl>
 
-The <dfn>privacy budget store</dfn> is a [=map=] whose keys are
-[=privacy budget keys=] and whose values are [=floats=].
-
-To <dfn>deduct privacy budget</dfn> given a [=privacy budget key=] |key|,
-[=float=] |epsilon|, integer |sensitivity|, and integer |globalSensitivity|:
+To <dfn>deduct privacy budget</dfn>
+given an [=environment settings object=] |settings|,
+a [=privacy budget key=] |key|,
+[=float=] |epsilon|,
+integer |sensitivity|,
+and integer |globalSensitivity|:
 
 1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
-     its value of |key| to be a [=user agent=]-defined value.
+    its value of |key| to be a [=user agent=]-defined value.
 
 1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
     in the [=privacy budget store=].
@@ -931,51 +946,219 @@ To <dfn>deduct privacy budget</dfn> given a [=privacy budget key=] |key|,
 1.  Return whether |newValue| is greater than or equal to 0.
 
 
-### Clearing ### {#budget-store-clearing}
+### Epoch Start Store ### {#s-epoch-start}
+
+An [=epoch=] starts at a randomly-selected time
+for each [=site=].
+This ensures that any bias in aggregates
+that arises from a [=privacy budget=] reaching zero
+is averaged across all the contributions from all [=users=].
+
+The <dfn>epoch start store</dfn> is a [=map=] keyed by [=site=]
+with values that are [=moments=].
+
+To <dfn>get the current epoch</dfn>
+given an [=environment settings object=] |settings|,
+a [=site=] |site|,
+and [=moment=] |now|:
+
+1.  Let |period| be the duration of an [=epoch=] (i.e., 86400 seconds).
+
+1.  If the [=epoch start store=] does not [=map/contain=] |site|, [=map/set=]
+    its value to |now|, minus a [=duration=]
+    that is randomly selected
+    from between 0 (inclusive) and a duration of [=epoch=] (exclusive).
+
+1.  Let |start| be the result of [=map/get|getting the value=] of |site|
+    from the [=epoch start store=].
+
+1.  Let |elapsed| be |now| - |start| / |period|.
+
+1.  Return |elapsed| as an integer, rounded towards negative Infinity.
+
+
+### Clearing Privacy Budget State ### {#clear-budget-store}
 
 A [=user agent=] might present the option to clear storage.
 These exist for two reasons:
 
 *   Privacy toward sites,
-    so that the sites cannot recognize the [=user=] in future interactions.
-    (that is, to [=same site recognition=])
+    so that the sites cannot recognize the [=user=] in future interactions
+    (that is, to prevent [=same site recognition=]).
 
 *   Removing traces of activity locally,
     so that other users of a computer
     cannot access browsing history.
 
-Clearing privacy budget state has an adverse effect on privacy toward sites,
-because it might allow sites to gain more information
-through attribution.
-Retaining any per-site information
+Clearing the state that tracks [=privacy budget=] expenditure
+has an adverse effect on privacy toward sites.
+Sites would then be able to gain more information
+from attribution.
+
+
+#### Clearing Site Data #### {#clear-site-data}
+
+When clearing site data,
+but retaining browsing history,
+a [=user agent=] can [=map/set=] the value
+in the [=privacy budget store=] to 0 for all [=epochs=]
+up to the [=get the current epoch|current epoch=],
+starting from the [=get the starting epoch for attribution|earliest available epoch=]
+for all affected [=sites=].
+
+
+#### Clearing Browsing History #### {#clear-browsing-history}
+
+Updating the [=privacy budget store=] is insufficient
+when clearing browsing history.
+Retaining per-[=site=] information
 necessary to prevent privacy loss toward sites
 leaves information about visits to sites
-for other users of a computer to discover.
+for other users of a computer to discover
+when removing browsing history.
 
-To this end, [=user agents=] can both
-remove per-site information
-and globally disable the attribution API.
-Attribution needs to be disabled for one [=epoch=]
-from the point that state is discarded.
-Otherwise, site that expends its budget
-immediately prior to the clearing of state
-would be able to learn more through th eAPI
+When clearing browsing history,
+[=user agents=] need to
+remove all per-[=site=] [=privacy budget=] information
+(that is, remove entries from both the [=privacy budget store=]
+and the [=epoch start store=]).
+[=User agents=] also need to ensure that
+any subsequent [=privacy budget=] expenditure
+cannot cause privacy loss in excess of configured limits
+as a result of losing that information.
+
+This can be achieved by disabling attribution
+for a period between one and two [=epochs=]
+from the point that browsing history is discarded.
+Otherwise, a [=site=] that expends its budget
+immediately prior to the clearing of history
+would be able to learn more through API
 than it could without the clearing of state.
 
-This does not apply if only some interactions with a site are cleared,
-such as if local storage of activity over a set time window are removed.
-This only applies if all interactions with a site
-need to be removed.
+<p class=note>
+This disables the API for up to <em>two</em> [=epochs=]
+for affected [=sites=].
+Because the [=epoch start store=] is cleared,
+the start of any newly-defined [=epoch=] for that [=site=]
+becomes unknown.
+Any new [=epoch=] will [start at a fresh randomly-selected time](#s-epoch-start),
+which cannot overlap with any [=epoch=] that might have been defined
+before history was cleared.
 
-A [=user agent=] therefore has to remember when state was last cleared,
-preventing budget expenditure until that time elapses.
-A site that has an [=epoch=] that starts within
-that offers selective deletion of history,
+A [=user agent=] remembers when history was last cleared
+in the [=last browsing history clear=] variable.
+This is used to prevent [=privacy budget|budget=] expenditure
+until it is guaranteed that a [=site=] cannot exceed
+the [=user agent=]-chosen maximum allowed [=privacy budget=].
+
+The [=get the starting epoch for attribution=] algorithm
+ensures that an [=impression site=]
+cannot make queries [=impressions=] from any [=epoch=]
+that starts within one [=epoch=] [=duration=]
+from when state is cleared.
+
+
+#### Removing Impressions #### {#removing-impressions}
+
+A [=user agent=] that clears site state for a [=site=]
+must discard all [=impression store|saved impressions=]
+that were saved during the affected period
+with a [=same site|matching=] [=impression/impression site=]
+or [=impression/conversion site=].
+For an [=impression site=],
+these [=impressions=] relate to activity that was cleared.
+A [=conversion site=] that has had state cleared
+will not be able to use these [=impressions=].
+
+[=Impressions=] that have a [=same site|matching=] [=impression/intermediary site=]
+may be cleared.
+
+
+### Last Browsing History Clear Time ### {#last-clear}
+
+The <dfn>last browsing history clear</dfn> is a [=moment=]
+that tracks when browsing history was last cleared.
+The [=last browsing history clear=] value is updated
+to the [=current high resolution time=]
+when any [=site=]-level state is cleared
+at the request of a [=user=].
+The value is initially unset.
+
+<p class=note>
+A [=user agent=] that offers selective deletion of history,
 such as the removal of state for a single site,
 could partition this value so that other sites remain unaffected.
-However, this cannot use too many partitions,
-or the choice of partition will correlate strongly with site identity.
+However, any choice to partition leaks some information
+that might reveal that a specific site had been visited.
+Strictly limiting the number of partitions
+is necessary to make this information less useful.
+This specification describes algorithms that provide the strongest privacy,
+where no such partitioning is used.
 
+As an optional optimization,
+updating the [=last browsing history clear=] can be skipped if:
+
+*   All interactions that are cleared are with [=sites=]
+    that have other uncleared interactions.
+*   All cleared interactions occuring during [=epochs=]
+    where other interactions with the same [=site=] were retained.
+*   All affected [=sites=] have a value in the [=epoch start store=].
+
+If these conditions are true,
+the [=last browsing history clear=] does not need to be updated.
+Instead, the [=privacy budget store=] must be updated
+by [=map/set|setting=] a value of 0
+for all [=privacy budget key=] combinations that can be formed
+from every affected [=sites=] and [=epochs=].
+
+<p class=note>
+This optimization relies on the [=user agent=]
+having retained information
+about interactions with affected [=sites=]
+in the affected [=epochs=].
+This only works because any of the retained interactions
+could have resulted in exhausting the budget.
+
+A [=user agent=] may clear data
+from the [=privacy budget store=] and [=epoch start store=]
+when the API is [[#opt-out|disabled]].
+In that case, if the API is re-enabled,
+there is no way to determine what budget was expended
+prior to the API being [[#opt-out|disabled]].
+In that case, a [=user agent=] can update
+the value [=last browsing history clear=]
+to ensure that [=privacy budgets=] are not inadvertently exceeded.
+
+To <dfn>get the starting epoch for attribution</dfn>
+given [=site=] site:
+
+1.  Let |startEpoch| be a [=user agent=]-defined value
+    for the earliest [=epoch=]
+    that is supported for attribution.
+
+1.  If the [=last browsing history clear=] is set,
+    perform the following steps:
+
+    1.  Let |clearEpoch| be the result of [=get the current epoch=]
+        with |site| and the value of [=last browsing history clear=].
+
+        <p class=note>
+        This is the one case where a [=get the current epoch=]
+        can return a negative value.
+
+    1.  Set |clearEpoch| to |clearEpoch| + 2.
+
+        <p class=note>
+        Adding <em>two</em> is necessary to that the [=epoch=]
+        does not overlap with an [=epoch=]
+        before browsing history--
+        and the [=epoch start store=]--
+        was cleared.
+
+    1.  If |clearEpoch| is greater than |startEpoch|,
+        return |clearEpoch|.
+
+1.  Return |startEpoch|.
 
 
 ## Save Impression Algorithm ## {#save-impression-api-operation}
@@ -1067,9 +1250,13 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
 1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
 
-1.  For each |epoch| starting from the oldest [=epoch=] supported by the
-    [=user agent=] to the current [=privacy budget epoch=]:
-    <!-- TODO: Clarify how epoch iteration works. -->
+1.  Let |currentEpoch| be the result of [=get the current epoch=]
+    with |site| and |now|.
+
+1.  Let |startEpoch| be the result of [=get the starting epoch for attribution=]
+    with |site|.
+
+1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
 
     1.  Let |impressions| be the result of invoking [=common matching logic=]
         with |options|, |epoch|, and |now|.
@@ -1857,6 +2044,8 @@ urlPrefix: https://infra.spec.whatwg.org/; spec: infra; type: dfn;
     text: set; url: #sets
 urlPrefix: https://storage.spec.whatwg.org/; spec: storage; type: dfn;
     text: storage key
+urlPrefix: https://w3ctag.github.io/privacy-principles/; type: dfn;
+    text: same site recognition
 </pre>
 <pre class=biblio>
 {

--- a/api.bs
+++ b/api.bs
@@ -1991,7 +1991,7 @@ until it is guaranteed that a [=site=] cannot exceed
 the [=user agent=]-chosen maximum allowed [=privacy budget=].
 
 The [=get the starting epoch for attribution=] algorithm
-ensures that an [=impression site=]
+ensures that a [=conversion site=]
 cannot query [=impressions=] from any [=epoch=]
 that starts within one [=epoch=] [=duration=]
 from when state is cleared.

--- a/api.bs
+++ b/api.bs
@@ -1800,6 +1800,116 @@ of candidate impressions.
 # Privacy Considerations # {#privacy}
 
 
+## Information Exposed by the Private Attribution API ## {#privacy-exposure}
+
+The [=impression store=] and [=privacy budget store=]
+contain information about a cross-section of browsing activity.
+As use of the API increases,
+so does the scope of this information.
+However, most of the information written to these stores
+is never disclosed.
+Because attribution is performed on the device
+(<dfn ignore=''>on-device attribution</dfn>),
+only information about attributed conversions is exposed by the
+Private Attribution API. This contrasts with other schemes in which
+information about both impressions and conversions is sent to the
+aggregation service for <dfn ignore=''>off-device attribution</dfn>.
+In the latter class of schemes, the amount of information
+that could be revealed in a compromise of the aggregation service
+(or in a compromise of communication with the aggregation service)
+is significantly larger.
+
+When the Private Attribution API makes an attribution, information
+about that attribution is released from the device
+only to the extent the [[#dp|differential privacy]] restrictions allow.
+
+While the Private Attribution API is intended to measure
+the association of relatively infrequent conversion events
+with a limited set of related impression candidates,
+it is important to consider how the API might be misused
+for larger-scale data collection.
+The requirement that impressions enumerate
+the possible [=conversion sites=] (and vice-versa)
+has an important role in preventing misuse of the API
+for mass data collection, and in making attempts
+at such misuse more visible.
+
+<p class=issue>
+It is unclear whether the [=privacy budget store=] should be cleared whenever
+the [=impression store=] is cleared. On one hand, it contains information about
+browsing activity, so it is desirable to include it when clearing browsing activity.
+On the other hand, it is only possible to strictly adhere to the requirements of
+the differential privacy mechanism if information about a fully- or partially-
+depleted privacy budget is maintained until that budget is no longer relevant
+(i.e. the end of the [=privacy budget epoch=]).
+
+
+## Disabling the Private Attribution API ## {#privacy-opt-out}
+
+The Private Attribution API
+is designed to reveal only aggregate information.
+The use of [[#dp|differential privacy]]
+limits the chance of determining whether any particular user
+contributed to the aggregated output.
+However, some users may still prefer
+not to participate in attribution measurement.
+As discussed in [[#opt-out]], the user agent must provide
+a mechanism for the user to disable the Private Attribution API.
+
+To minimize the risk of fingerprinting,
+and to prevent discrimination
+against users who choose to disable the Private Attribution API,
+sites must not be able to detect that the API is disabled.
+Specifically, all calls to the Private Attribution API
+that are otherwise valid
+must complete successfully, even when the API is disabled.
+The only difference in behavior
+is that [=conversion reports=] returned when the API is disabled
+will never report any [=conversion value=].
+Because the reports are encrypted,
+this difference cannot be detected
+by the site receiving the conversion report.
+
+
+## Including Identifying Information with Saved Impressions ## {#privacy-impression-store}
+
+Sites are able to encode some amount of data
+in impressions,
+using {{PrivateAttributionConversionOptions/filterData}}
+or other fields.
+The API does not prevent sites from encoding user identifiers
+in these fields.
+The attribution process can use this data
+when constructing a [=conversion report=],
+which implies some risk of that identifying information
+becoming available to the site that receives that report.
+The following measures mitigate this risk:
+
+*   The [=impression store=] cannot be read directly.
+    Thus, identifiers are only usable for tracking
+    to the extent information about them
+    is revealed in [=conversion reports=].
+*   The information in [=conversion reports=] is only revealed
+    after aggregation and the addition of noise.
+*   Users have the ability to [[#removing-impressions|clear the impression store]].
+*   No impressions are saved to the impression store
+    when the Private Attribution API is [[#opt-out|disabled]].
+
+
+## Use in Third-party Contexts ## {#privacy-third-party-contexts}
+
+The Private Attribution API is available even in third-party contexts.
+In particular, a third-party iframe
+may call <a method for=PrivateAttribution>saveImpression()</a>.
+Note, however, that the impression is recorded with the [=site=]
+of the top-level navigation context, not the [=origin=] of the iframe.
+
+While the availability of the API in third-party contexts
+carries some increase in privacy risk,
+this support is deemed necessary
+because iframes are commonly used to display advertisements.
+
+
 ## Clearing API State ## {#clear-budget-store}
 
 A [=user agent=] might present the option to clear storage.
@@ -1916,115 +2026,6 @@ will not be able to use these [=impressions=].
 
 [=Impressions=] that have a [=same site|matching=] [=impression/intermediary site=]
 may be cleared.
-
-
-## Information Exposed by the Private Attribution API ## {#privacy-exposure}
-
-The [=impression store=] and [=privacy budget store=]
-contain information about a cross-section of browsing activity.
-As use of the API increases,
-so does the scope of this information.
-However, most of the information written to these stores
-is never disclosed.
-Because attribution is performed on the device
-(<dfn ignore=''>on-device attribution</dfn>),
-only information about attributed conversions is exposed by the
-Private Attribution API. This contrasts with other schemes in which
-information about both impressions and conversions is sent to the
-aggregation service for <dfn ignore=''>off-device attribution</dfn>.
-In the latter class of schemes, the amount of information
-that could be revealed in a compromise of the aggregation service
-(or in a compromise of communication with the aggregation service)
-is significantly larger.
-
-When the Private Attribution API makes an attribution, information
-about that attribution is released from the device
-only to the extent the [[#dp|differential privacy]] restrictions allow.
-
-While the Private Attribution API is intended to measure
-the association of relatively infrequent conversion events
-with a limited set of related impression candidates,
-it is important to consider how the API might be misused
-for larger-scale data collection.
-The requirement that impressions enumerate
-the possible [=conversion sites=] (and vice-versa)
-has an important role in preventing misuse of the API
-for mass data collection, and in making attempts
-at such misuse more visible.
-
-<p class=issue>
-It is unclear whether the [=privacy budget store=] should be cleared whenever
-the [=impression store=] is cleared. On one hand, it contains information about
-browsing activity, so it is desirable to include it when clearing browsing activity.
-On the other hand, it is only possible to strictly adhere to the requirements of
-the differential privacy mechanism if information about a fully- or partially-
-depleted privacy budget is maintained until that budget is no longer relevant
-(i.e. the end of the [=privacy budget epoch=]).
-
-## Disabling the Private Attribution API ## {#privacy-opt-out}
-
-The Private Attribution API
-is designed to reveal only aggregate information.
-The use of [[#dp|differential privacy]]
-limits the chance of determining whether any particular user
-contributed to the aggregated output.
-However, some users may still prefer
-not to participate in attribution measurement.
-As discussed in [[#opt-out]], the user agent must provide
-a mechanism for the user to disable the Private Attribution API.
-
-To minimize the risk of fingerprinting,
-and to prevent discrimination
-against users who choose to disable the Private Attribution API,
-sites must not be able to detect that the API is disabled.
-Specifically, all calls to the Private Attribution API
-that are otherwise valid
-must complete successfully, even when the API is disabled.
-The only difference in behavior
-is that [=conversion reports=] returned when the API is disabled
-will never report any [=conversion value=].
-Because the reports are encrypted,
-this difference cannot be detected
-by the site receiving the conversion report.
-
-
-## Including Identifying Information with Saved Impressions ## {#privacy-impression-store}
-
-Sites are able to encode some amount of data
-in impressions,
-using {{PrivateAttributionConversionOptions/filterData}}
-or other fields.
-The API does not prevent sites from encoding user identifiers
-in these fields.
-The attribution process can use this data
-when constructing a [=conversion report=],
-which implies some risk of that identifying information
-becoming available to the site that receives that report.
-The following measures mitigate this risk:
-
-*   The [=impression store=] cannot be read directly.
-    Thus, identifiers are only usable for tracking
-    to the extent information about them
-    is revealed in [=conversion reports=].
-*   The information in [=conversion reports=] is only revealed
-    after aggregation and the addition of noise.
-*   Users have the ability to [[#removing-impressions|clear the impression store]].
-*   No impressions are saved to the impression store
-    when the Private Attribution API is [[#opt-out|disabled]].
-
-
-## Use in Third-party Contexts ## {#privacy-third-party-contexts}
-
-The Private Attribution API is available even in third-party contexts.
-In particular, a third-party iframe
-may call <a method for=PrivateAttribution>saveImpression()</a>.
-Note, however, that the impression is recorded with the [=site=]
-of the top-level navigation context, not the [=origin=] of the iframe.
-
-While the availability of the API in third-party contexts
-carries some increase in privacy risk,
-this support is deemed necessary
-because iframes are commonly used to display advertisements.
 
 
 # Acknowledgements # {#ack}

--- a/api.bs
+++ b/api.bs
@@ -864,20 +864,6 @@ excludes expired [=impressions=] from [=attribution=]. However, the
 [=user agent=] should not retain expired [=impressions=] indefinitely.
 
 
-### Clearing Impression State ### {#impression-store-clearing}
-
-A mechanism must be provided to clear the impression store.
-For example, the impression store could be cleared
-upon activation of the control that
-[[#opt-out|disables]] the Private Attribution API.
-
-It is recommended that any mechanism a user agent provides
-to clear stored data (history, cookies, etc.)
-be extended to cover the impression store.
-[[#clear-budget-store]] provides more detailed information
-on the clearing of stored data.
-
-
 ## State For Privacy Budget Management ## {#privacy-state}
 
 [=User agents=] maintain three pieces of state
@@ -962,12 +948,12 @@ given an [=environment settings object=] |settings|,
 a [=site=] |site|,
 and [=moment=] |now|:
 
-1.  Let |period| be the duration of an [=epoch=] (i.e., 86400 seconds).
+1.  Let |period| be the [=duration=] of one [=epoch=] (i.e., 86400 seconds).
 
 1.  If the [=epoch start store=] does not [=map/contain=] |site|, [=map/set=]
     its value to |now|, minus a [=duration=]
     that is randomly selected
-    from between 0 (inclusive) and a duration of [=epoch=] (exclusive).
+    from between 0 (inclusive) and |period| (exclusive).
 
 1.  Let |start| be the result of [=map/get|getting the value=] of |site|
     from the [=epoch start store=].
@@ -975,103 +961,6 @@ and [=moment=] |now|:
 1.  Let |elapsed| be |now| - |start| / |period|.
 
 1.  Return |elapsed| as an integer, rounded towards negative Infinity.
-
-
-### Clearing Privacy Budget State ### {#clear-budget-store}
-
-A [=user agent=] might present the option to clear storage.
-These exist for two reasons:
-
-*   Privacy toward sites,
-    so that the sites cannot recognize the [=user=] in future interactions
-    (that is, to prevent [=same site recognition=]).
-
-*   Removing traces of activity locally,
-    so that other users of a computer
-    cannot access browsing history.
-
-Clearing the state that tracks [=privacy budget=] expenditure
-has an adverse effect on privacy toward sites.
-Sites would then be able to gain more information
-from attribution.
-
-
-#### Clearing Site Data #### {#clear-site-data}
-
-When clearing site data,
-but retaining browsing history,
-a [=user agent=] can [=map/set=] the value
-in the [=privacy budget store=] to 0 for all [=epochs=]
-up to the [=get the current epoch|current epoch=],
-starting from the [=get the starting epoch for attribution|earliest available epoch=]
-for all affected [=sites=].
-
-
-#### Clearing Browsing History #### {#clear-browsing-history}
-
-Updating the [=privacy budget store=] is insufficient
-when clearing browsing history.
-Retaining per-[=site=] information
-necessary to prevent privacy loss toward sites
-leaves information about visits to sites
-for other users of a computer to discover
-when removing browsing history.
-
-When clearing browsing history,
-[=user agents=] need to
-remove all per-[=site=] [=privacy budget=] information
-(that is, remove entries from both the [=privacy budget store=]
-and the [=epoch start store=]).
-[=User agents=] also need to ensure that
-any subsequent [=privacy budget=] expenditure
-cannot cause privacy loss in excess of configured limits
-as a result of losing that information.
-
-This can be achieved by disabling attribution
-for a period between one and two [=epochs=]
-from the point that browsing history is discarded.
-Otherwise, a [=site=] that expends its budget
-immediately prior to the clearing of history
-would be able to learn more through API
-than it could without the clearing of state.
-
-<p class=note>
-This disables the API for up to <em>two</em> [=epochs=]
-for affected [=sites=].
-Because the [=epoch start store=] is cleared,
-the start of any newly-defined [=epoch=] for that [=site=]
-becomes unknown.
-Any new [=epoch=] will [start at a fresh randomly-selected time](#s-epoch-start),
-which cannot overlap with any [=epoch=] that might have been defined
-before history was cleared.
-
-A [=user agent=] remembers when history was last cleared
-in the [=last browsing history clear=] variable.
-This is used to prevent [=privacy budget|budget=] expenditure
-until it is guaranteed that a [=site=] cannot exceed
-the [=user agent=]-chosen maximum allowed [=privacy budget=].
-
-The [=get the starting epoch for attribution=] algorithm
-ensures that an [=impression site=]
-cannot make queries [=impressions=] from any [=epoch=]
-that starts within one [=epoch=] [=duration=]
-from when state is cleared.
-
-
-#### Removing Impressions #### {#removing-impressions}
-
-A [=user agent=] that clears site state for a [=site=]
-must discard all [=impression store|saved impressions=]
-that were saved during the affected period
-with a [=same site|matching=] [=impression/impression site=]
-or [=impression/conversion site=].
-For an [=impression site=],
-these [=impressions=] relate to activity that was cleared.
-A [=conversion site=] that has had state cleared
-will not be able to use these [=impressions=].
-
-[=Impressions=] that have a [=same site|matching=] [=impression/intermediary site=]
-may be cleared.
 
 
 ### Last Browsing History Clear Time ### {#last-clear}
@@ -1084,16 +973,21 @@ when any [=site=]-level state is cleared
 at the request of a [=user=].
 The value is initially unset.
 
-<p class=note>
+<div class=note>
 A [=user agent=] that offers selective deletion of history,
 such as the removal of state for a single site,
 could partition this value so that other sites remain unaffected.
 However, any choice to partition leaks some information
-that might reveal that a specific site had been visited.
+that might reveal that a specific site had been visited
+to any entity that can access stored data.
 Strictly limiting the number of partitions
-is necessary to make this information less useful.
-This specification describes algorithms that provide the strongest privacy,
-where no such partitioning is used.
+might make this information less useful
+in terms of revealing that a particular site was visited.
+
+This specification describes algorithms that do not including partition.
+This guarantees that stored data does not reveal anything
+about browsing history.
+</div>
 
 As an optional optimization,
 updating the [=last browsing history clear=] can be skipped if:
@@ -1104,7 +998,7 @@ updating the [=last browsing history clear=] can be skipped if:
     where other interactions with the same [=site=] were retained.
 *   All affected [=sites=] have a value in the [=epoch start store=].
 
-If these conditions are true,
+If all three conditions are true,
 the [=last browsing history clear=] does not need to be updated.
 Instead, the [=privacy budget store=] must be updated
 by [=map/set|setting=] a value of 0
@@ -1118,16 +1012,6 @@ about interactions with affected [=sites=]
 in the affected [=epochs=].
 This only works because any of the retained interactions
 could have resulted in exhausting the budget.
-
-A [=user agent=] may clear data
-from the [=privacy budget store=] and [=epoch start store=]
-when the API is [[#opt-out|disabled]].
-In that case, if the API is re-enabled,
-there is no way to determine what budget was expended
-prior to the API being [[#opt-out|disabled]].
-In that case, a [=user agent=] can update
-the value [=last browsing history clear=]
-to ensure that [=privacy budgets=] are not inadvertently exceeded.
 
 To <dfn>get the starting epoch for attribution</dfn>
 given [=site=] site:
@@ -1143,8 +1027,10 @@ given [=site=] site:
         with |site| and the value of [=last browsing history clear=].
 
         <p class=note>
-        This is the one case where a [=get the current epoch=]
+        This use of [=get the current epoch=]
         can return a negative value.
+        This is because the value in [=epoch start store=]
+        is likely to be set to a time be after history was last cleared.
 
     1.  Set |clearEpoch| to |clearEpoch| + 2.
 
@@ -1801,7 +1687,7 @@ of harmful information flow through the impression store:
     is distinguishable from the value it would have
     absent any user's contribution.
 *   Users can explicitly
-    [[#impression-store-clearing|clear the impression store]].
+    [[#removing-impressions|clear stored impressions]].
 *   It is recommended that user agents limit how long
     data can persist in the impression store,
     even absent explicit user action,
@@ -1914,6 +1800,124 @@ of candidate impressions.
 # Privacy Considerations # {#privacy}
 
 
+## Clearing API State ## {#clear-budget-store}
+
+A [=user agent=] might present the option to clear storage.
+These exist for two reasons:
+
+*   Privacy toward sites,
+    so that the sites cannot recognize the [=user=] in future interactions
+    (that is, to prevent [=same site recognition=]).
+
+*   Removing traces of activity locally,
+    so that other users of a computer
+    cannot access browsing history.
+
+Clearing the state that tracks [=privacy budget=] expenditure
+has an adverse effect on privacy toward sites.
+Sites would then be able to gain more information
+from attribution.
+
+A [=user agent=] may clear data
+from the [=privacy budget store=] and [=epoch start store=]
+when the API is [[#opt-out|disabled]].
+In that case, if the API is re-enabled,
+there is no way to determine what budget was expended
+prior to the API being [[#opt-out|disabled]].
+In that case, a [=user agent=] can update
+the value [=last browsing history clear=]
+to ensure that [=privacy budgets=] are not inadvertently exceeded.
+
+
+### Clearing Site Data ### {#clear-site-data}
+
+When clearing site data,
+but retaining browsing history,
+a [=user agent=] can [=map/set=] the value
+in the [=privacy budget store=] to 0 for all [=epochs=]
+up to the [=get the current epoch|current epoch=],
+starting from the [=get the starting epoch for attribution|earliest available epoch=]
+for all affected [=sites=].
+
+
+### Clearing Browsing History ### {#clear-browsing-history}
+
+Updating the [=privacy budget store=] is insufficient
+when clearing browsing history.
+Retaining per-[=site=] information
+necessary to prevent privacy loss toward sites
+leaves information about visits to sites
+for other users of a computer to discover
+when removing browsing history.
+
+When clearing browsing history,
+[=user agents=] need to
+remove all per-[=site=] [=privacy budget=] information
+(that is, remove entries from both the [=privacy budget store=]
+and the [=epoch start store=]).
+[=User agents=] also need to ensure that
+any subsequent [=privacy budget=] expenditure
+cannot cause privacy loss in excess of configured limits
+as a result of losing that information.
+
+This can be achieved by disabling attribution
+for a period between one and two [=epochs=]
+from the point that browsing history is discarded.
+Otherwise, a [=site=] that expends its budget
+immediately prior to the clearing of history
+would be able to learn more through API
+than it could without the clearing of state.
+
+<p class=note>
+This disables the API for up to <em>two</em> [=epochs=]
+for affected [=sites=].
+Because the [=epoch start store=] is cleared,
+the start of any newly-defined [=epoch=] for that [=site=]
+becomes unknown.
+Any new [=epoch=] will [start at a fresh randomly-selected time](#s-epoch-start),
+which cannot overlap with any [=epoch=] that might have been defined
+before history was cleared.
+
+A [=user agent=] remembers when history was last cleared
+in the [=last browsing history clear=] variable.
+This is used to prevent [=privacy budget|budget=] expenditure
+until it is guaranteed that a [=site=] cannot exceed
+the [=user agent=]-chosen maximum allowed [=privacy budget=].
+
+The [=get the starting epoch for attribution=] algorithm
+ensures that an [=impression site=]
+cannot make queries [=impressions=] from any [=epoch=]
+that starts within one [=epoch=] [=duration=]
+from when state is cleared.
+
+
+### Clearing Impressions ### {#removing-impressions}
+
+A mechanism must be provided to clear the impression store.
+For example, the impression store could be cleared
+upon activation of the control that
+[[#opt-out|disables]] the Private Attribution API.
+
+It is recommended that any mechanism a [=user agent=] provides
+to clear stored data (history, cookies, etc.)
+be extended to cover the impression store.
+[[#clear-budget-store]] provides more detailed information
+on the clearing of stored data.
+
+A [=user agent=] that clears state for a [=site=]
+must discard all [=impression store|saved impressions=]
+that were saved during the affected period
+with a [=same site|matching=] [=impression/impression site=]
+or [=impression/conversion site=].
+For an [=impression site=],
+these [=impressions=] relate to activity that was cleared.
+A [=conversion site=] that has had state cleared
+will not be able to use these [=impressions=].
+
+[=Impressions=] that have a [=same site|matching=] [=impression/intermediary site=]
+may be cleared.
+
+
 ## Information Exposed by the Private Attribution API ## {#privacy-exposure}
 
 The [=impression store=] and [=privacy budget store=]
@@ -2004,7 +2008,7 @@ The following measures mitigate this risk:
     is revealed in [=conversion reports=].
 *   The information in [=conversion reports=] is only revealed
     after aggregation and the addition of noise.
-*   Users have the ability to [[#impression-store-clearing|clear the impression store]].
+*   Users have the ability to [[#removing-impressions|clear the impression store]].
 *   No impressions are saved to the impression store
     when the Private Attribution API is [[#opt-out|disabled]].
 


### PR DESCRIPTION
This turned into a bit of an epic, but it implements the changes we
discussed about site-state clearing, epoch start time, and all the
associated logic.

This defines when epochs start (randomly, as agreed).

This defines a store for that per-site state and integrates a new
algorithm for getting the current epoch.

It defines a persistent clear-state time variable that tracks when any
site state was cleared.  This value blocks out use of the API globally
for a period.

I've added notes about partitioning the state-cleared variable, but not
specified anything for that.  That seems like a reasonable balance to
me; as the text says, this is the most private option.

Closes #17.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/pull/121.html" title="Last updated on Apr 1, 2025, 11:20 PM UTC (e97b746)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/121/8c1f6c2...e97b746.html" title="Last updated on Apr 1, 2025, 11:20 PM UTC (e97b746)">Diff</a>