### PR TITLE
Editorial: fix "switch" clause wrapping

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -978,14 +978,14 @@ and <a dictionary lt=PrivateAttributionConversionOptions>|options|</a>:
 1. Validate the page-supplied API inputs:
     1.  Switch on the value of <a dict-member for=PrivateAttributionConversionOptions>logic</a>:
         <dl class="switch">
+            :   <a enum-value for=PrivateAttributionLogic>"last-touch"</a>
+            ::  Perform the following steps:
+                1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a> is 0,
+                    throw a {{RangeError}}.
+                1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a>
+                    is greater than <a dict-member for=PrivateAttributionConversionOptions>maxValue</a>,
+                    throw a {{RangeError}}.
         </dl>
-        :   <a enum-value for=PrivateAttributionLogic>"last-touch"</a>
-        ::  Perform the following steps:
-            1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a> is 0,
-                throw a {{RangeError}}.
-            1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a>
-                is greater than <a dict-member for=PrivateAttributionConversionOptions>maxValue</a>,
-                throw a {{RangeError}}.
     1. If |options|.{{PrivateAttributionConversionOptions/lookbackDays}} is 0,
         throw a {{RangeError}}.
 1.  Let |report| be an [=create an all-zero histogram|all-zero histogram=].


### PR DESCRIPTION
The `<dl class="switch">` element did not fully wrap the inner clause, preventing Bikeshed from applying the right styles to the clause.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/ppa/pull/124.html" title="Last updated on Mar 31, 2025, 5:56 PM UTC (eab037d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/124/6832973...tidoust:eab037d.html" title="Last updated on Mar 31, 2025, 5:56 PM UTC (eab037d)">Diff</a>