### PR TITLE
Add text about the choice of clock 

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -985,7 +985,7 @@ The <dfn>last browsing history clear</dfn> is a [=moment=]
 using the [=wall clock=]
 that tracks when browsing history was last cleared.
 The [=last browsing history clear=] value is updated
-to the [=current high resolution time=]
+to the [=current wall time=]
 when any [=site=]-level state is cleared
 at the request of a [=user=].
 The value is initially unset.
@@ -1073,7 +1073,7 @@ and given <a dictionary lt=PrivateAttributionImpressionOptions>|options|</a>:
 <!-- TODO: Check the {{PermissionPolicy/save-impression}} policy. -->
 
 1.  Collect the implicit API inputs from |settings|:
-    1.  The timestamp is set to the [=current high resolution time=].
+    1.  The timestamp is set to the [=current wall time=].
     1.  The [=impression site=] is set to the result of
         [=obtain a site|obtaining a site=] from the [=top-level origin=].
     1.  The [=intermediary site=] is set to
@@ -1104,7 +1104,7 @@ and <a dictionary lt=PrivateAttributionConversionOptions>|options|</a>:
 <!-- TODO: Check the {{PermissionPolicy/measure-conversion}} policy. -->
 
 1.  Collect the implicit API inputs from |settings|:
-    1.  Let |now| be the [=current high resolution time=].
+    1.  Let |now| be the [=current wall time=].
     1.  Let |topLevelSite| (the [=conversion site=]) be the result of
         [=obtain a site|obtaining a site=] from the [=top-level origin=].
     1.  The [=intermediary site=] is set to
@@ -2114,6 +2114,8 @@ urlPrefix: https://html.spec.whatwg.org/; spec: html; type: dfn
     text: site
     text: top-level origin; url: #concept-environment-top-level-origin
     text: iframe; url: #child-navigable
+urlPrefix: https://w3c.github.io/hr-time/; spec: hr-time; type: dfn
+    text: current wall time
 urlPrefix: https://infra.spec.whatwg.org/; spec: infra; type: dfn;
     text: user agent
     text: set; url: #sets

--- a/api.bs
+++ b/api.bs
@@ -957,7 +957,8 @@ that arises from a [=privacy budget=] reaching zero
 is averaged across all the contributions from all [=users=].
 
 The <dfn>epoch start store</dfn> is a [=map=] keyed by [=site=]
-with values that are [=moments=].
+with values that are [=moments=]
+from the [=wall clock=].
 
 To <dfn>get the current epoch</dfn>
 given a [=site=] |site|,
@@ -981,6 +982,7 @@ and [=moment=] |now|:
 ### Last Browsing History Clear Time ### {#last-clear}
 
 The <dfn>last browsing history clear</dfn> is a [=moment=]
+using the [=wall clock=]
 that tracks when browsing history was last cleared.
 The [=last browsing history clear=] value is updated
 to the [=current high resolution time=]
@@ -1817,6 +1819,15 @@ of candidate impressions.
 
 # Privacy Considerations # {#privacy}
 
+The main privacy goal of this API is
+to ensure that providing sites with the ability to perform attribution
+does not improve their ability to perform [=cross-site recognition=].
+
+This section provides more information
+about the protections necessary to achieve this goal.
+Additional discussion talk about secondary privacy goals,
+such as the prevention of [=same-site recognition=].
+
 
 ## Information Exposed by the Private Attribution API ## {#privacy-exposure}
 
@@ -1935,7 +1946,7 @@ These exist for two reasons:
 
 *   Privacy toward sites,
     so that the sites cannot recognize the [=user=] in future interactions
-    (that is, to prevent [=same site recognition=]).
+    (that is, to prevent [=same-site recognition=]).
 
 *   Removing traces of activity locally,
     so that other users of a computer
@@ -2044,6 +2055,43 @@ will not be able to use these [=impressions=].
 may be cleared.
 
 
+## Choice of Clock ## {#why-wall-clock}
+
+This API uses a [=wall clock=] as its basis for time.
+This is primarily because the API relies on a persistent notion of time.
+A [=monotonic clock=] is only defined during a single execution of a [=user agent=],
+so it has no guarantee of consistency if a [=user agent=] is restarted.
+
+A [=wall clock=] can be adjusted to account for errors that might accumulate
+due to clock drift.
+A [=wall clock=] therefire is not guaranteed to always advance at a consistent rate,
+including the possibility that it might sometimes decrease.
+
+Decreases in the [=wall clock=] do not affect the privacy guarantees
+that this API provides.
+Only increases in the [=wall clock|clock=],
+can have an adverse privacy effect.
+Increases above the normal progress of time
+might result in the renewal of [=privacy budget=]
+more quickly than intended.
+
+For a clock that undergoes corrections within each [=epoch=],
+clock adjustments will have no privacy effect.
+A single correction that is sufficiently large
+might cause [=privacy budgets=] to be renewed
+ahead of schedule,
+resulting in a one-time increase in privacy loss.
+Continuous large corrections have the most serious effect on privacy,
+as each transition between epochs
+will release additional [=privacy budget=].
+
+Of course, any [=user agent=] that has a need for large
+or continuous
+corrections to its clock will likely be highly identifiable
+as a result of the time that it reports.
+That alone is likely enough to enable unwanted [=cross-site recognition=].
+
+
 # Acknowledgements # {#ack}
 
 This specification is the result of a lot of work from many people.
@@ -2066,7 +2114,8 @@ urlPrefix: https://infra.spec.whatwg.org/; spec: infra; type: dfn;
 urlPrefix: https://storage.spec.whatwg.org/; spec: storage; type: dfn;
     text: storage key
 urlPrefix: https://w3ctag.github.io/privacy-principles/; type: dfn;
-    text: same site recognition
+    text: cross-site recognition
+    text: same-site recognition
 </pre>
 <pre class=biblio>
 {

--- a/api.bs
+++ b/api.bs
@@ -2085,6 +2085,12 @@ Continuous large corrections have the most serious effect on privacy,
 as each transition between epochs
 will release additional [=privacy budget=].
 
+<p class=note>A very large increase in time
+that skips entire [=epochs=]
+does not result in additional privacy loss.
+No privacy loss is possible
+unless an [=impression=] can be [[#save-impression-api|saved]].
+
 Of course, any [=user agent=] that has a need for large
 or continuous
 corrections to its clock will likely be highly identifiable

--- a/api.bs
+++ b/api.bs
@@ -1825,7 +1825,7 @@ does not improve their ability to perform [=cross-site recognition=].
 
 This section provides more information
 about the protections necessary to achieve this goal.
-Additional discussion talk about secondary privacy goals,
+Additional discussion talks about secondary privacy goals,
 such as the prevention of [=same-site recognition=].
 
 
@@ -2064,7 +2064,7 @@ so it has no guarantee of consistency if a [=user agent=] is restarted.
 
 A [=wall clock=] can be adjusted to account for errors that might accumulate
 due to clock drift.
-A [=wall clock=] therefire is not guaranteed to always advance at a consistent rate,
+A [=wall clock=] therefore is not guaranteed to always advance at a consistent rate,
 including the possibility that it might sometimes decrease.
 
 Decreases in the [=wall clock=] do not affect the privacy guarantees


### PR DESCRIPTION
And an analysis of why our choice is acceptable.

I didn't have to rely on the fact that most clock adjustments are small,
except somewhat indirectly.  Instead, it mentions that large forward
adjustments that might cause a change of epoch each have an
instantaneous effect on privacy by refreshing the budget.

I had to add some additional context about privacy goals to this one,
so that the discussion on recognition made sense.

Closes #123.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/pull/128.html" title="Last updated on Apr 3, 2025, 9:58 PM UTC (322538a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/128/f63ab46...322538a.html" title="Last updated on Apr 3, 2025, 9:58 PM UTC (322538a)">Diff</a>