### PR TITLE
Provide histogram size when API is disabled

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1124,7 +1124,8 @@ and <a dictionary lt=PrivateAttributionConversionOptions>|options|</a>:
         </dl>
     1. If |options|.{{PrivateAttributionConversionOptions/lookbackDays}} is 0,
         throw a {{RangeError}}.
-1.  Let |report| be an [=create an all-zero histogram|all-zero histogram=].
+1.  Let |report| be the result of invoking [=create an all-zero histogram=] with
+    |options|.{{PrivateAttributionConversionOptions/histogramSize}}.
 1.  If the Private Attribution API is [[#opt-out|enabled]], set |report| to the
     result of [=do attribution and fill a histogram=] with |options|,
     |topLevelSite|, and |now|.
@@ -1173,7 +1174,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
         1.  If |budgetOk| is true, [=set/extend=] |matchedImpressions| with |impressions|.
 
-1.  If |matchedImpressions| [=set/is empty=], return the the result of invoking
+1.  If |matchedImpressions| [=set/is empty=], return the result of invoking
     [=create an all-zero histogram=] with
     |options|.{{PrivateAttributionConversionOptions/histogramSize}}.
 


### PR DESCRIPTION
The algorithm to create an empty histogram requires an integer size.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/131.html" title="Last updated on Apr 3, 2025, 9:57 PM UTC (7422854)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/131/f63ab46...apasel422:7422854.html" title="Last updated on Apr 3, 2025, 9:57 PM UTC (7422854)">Diff</a>