### PR TITLE
Fix erroneous references to impression-vs-conversion filterData

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -856,7 +856,7 @@ The [=impression store=] is a [=set=] of [=impression|impressions=]:
 
 <div dfn-for=impression link-for-hint=PrivateAttribution>
 <pre class=simpledef>
-<dfn>Filter Data</dfn>: The {{PrivateAttributionConversionOptions/filterData}} value passed to <a>saveImpression()</a>.
+<dfn>Filter Data</dfn>: The {{PrivateAttributionImpressionOptions/filterData}} value passed to <a>saveImpression()</a>.
 <dfn>Impression Site</dfn>: The [=impression site=] where <a>saveImpression()</a> was called.
 <dfn>Intermediary Site</dfn>: The [=intermediary site=] that called <a>saveImpression()</a>,
     or `undefined` if the API was invoked by the [=impression site=].
@@ -1905,7 +1905,7 @@ by the site receiving the conversion report.
 
 Sites are able to encode some amount of data
 in impressions,
-using {{PrivateAttributionConversionOptions/filterData}}
+using {{PrivateAttributionImpressionOptions/filterData}}
 or other fields.
 The API does not prevent sites from encoding user identifiers
 in these fields.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/133.html" title="Last updated on Apr 4, 2025, 1:20 PM UTC (7227473)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/133/c66a938...apasel422:7227473.html" title="Last updated on Apr 4, 2025, 1:20 PM UTC (7227473)">Diff</a>