### PR TITLE
Allow conversions to match a set of filter data values

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -610,15 +610,6 @@ The arguments to <a method for=PrivateAttribution>saveImpression()</a> are as fo
     An optional piece of metadata associated with the impression. The value
     can be used to identify which impressions may receive attribution
     from a [=conversion=].
-    <p class=note>It is intentional that on the impression side this field
-    defaults to 0, while on
-    {{PrivateAttributionConversionOptions/filterData|the conversion side}} it is
-    an <span class=allow-2119>optional</span> field without a default: A default
-    on the impression side means that implementations do not need to use a bit
-    to represent potential absence of the field for each impression in the
-    [=impression store=], while optionality on the conversion side means that
-    there is a way to match any filter data, which would not be possible if
-    there were a default integer value.
   </dd>
   <dt><dfn>conversionSites</dfn></dt>
   <dd>
@@ -705,7 +696,7 @@ contribute to the histogram, i.e., will be uniformly zero.
           lookbackDays: 14,
           impressionSites: ["publisher.example", "other.example"],
           intermediarySites: ["ad-tech.example"],
-          filterData: 2,
+          filterData: [2],
         };
       </xmp>
 
@@ -749,7 +740,7 @@ dictionary PrivateAttributionConversionOptions {
   required unsigned long histogramSize;
 
   unsigned long lookbackDays;
-  unsigned long filterData;
+  sequence<unsigned long> filterData = [];
   sequence<USVString> impressionSites = [];
   sequence<USVString> intermediarySites = [];
 
@@ -787,7 +778,7 @@ The arguments to <a method for=PrivateAttribution>measureConversion()</a> are as
   <dt><dfn>lookbackDays</dfn></dt>
   <dd>A positive integer number of days. Only impressions occurring within the past `lookbackDays` may match this [=conversion=]. If omitted, it is equivalent to an [=implementation-defined=] maximum.</dd>
   <dt><dfn>filterData</dfn></dt>
-  <dd>Only [=impressions=] having a [=impression/filter data=] value matching this value will be eligible to match this [=conversion=]. If omitted, all [=impression/filter data=] values will match.</dd>
+  <dd>A [=set=] of matching values. Only [=impressions=] having a [=impression/filter data=] value contained in this set will be eligible to match this [=conversion=]. If empty, all [=impression/filter data=] values will match.</dd>
   <dt><dfn>impressionSites</dfn></dt>
   <dd>A [=set=] of impression sites. Only [=impressions=] recorded where the [=impression site=] is in this set are eligible to match this [=conversion=]. If empty, any site will match.</dd>
   <dt><dfn>intermediarySites</dfn></dt>
@@ -1293,8 +1284,8 @@ To perform <dfn>common matching logic</dfn>, given
         and [=set/contains|does not contain=] |topLevelSite|,
         [=iteration/continue=].
 
-    1.  If |options|.{{PrivateAttributionConversionOptions/filterData}} [=map/exists=],
-        and it is not equal to |impression|'s [=impression/filter data=],
+    1.  If |options|.{{PrivateAttributionConversionOptions/filterData}} [=set/is empty|is not empty=]
+        and [=set/contains|does not contain=] |impression|'s [=impression/filter data=],
         [=iteration/continue=].
 
     1.  If |options|.{{PrivateAttributionConversionOptions/impressionSites}}


### PR DESCRIPTION
When the set is empty, any value matches.

Fixes #132.