### PR TITLE
Cache python dependencies for CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+    - uses: actions/cache@v4
       with:
-        cache: pip
-        cache-dependency-path: Makefile
+        path: venv
+        key: venv-${{ hashFiles('Makefile') }}
     - run: make

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,4 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        cache: pip
+        cache-dependency-path: Makefile
     - run: make


### PR DESCRIPTION
This caches pip depedencies so that builds run a little faster.

They are already pretty quick, but this might be faster yet.