### PR TITLE
Allow implementations to reject large conversion-site lists

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1238,6 +1238,9 @@ The <dfn method for=PrivateAttribution>saveImpression(|options|)</dfn> method st
         throw a {{RangeError}}.
     1.  Clamp |options|.{{PrivateAttributionImpressionOptions/lifetimeDays}} to
         the [=user agent=]'s upper limit.
+    1.  If the [=list/size=] of
+        |options|.{{PrivateAttributionImpressionOptions/conversionSites}} is
+        greater than an [=implementation-defined=] maximum value, throw a {{RangeError}}.
     1.  Let |conversionSites| be the [=set=] that is the result
         of invoking [=parse a site=]
         for each value in |options|.{{PrivateAttributionImpressionOptions/conversionSites}}.


### PR DESCRIPTION
Otherwise, it is possible for a saveImpression call to consume unbounded space.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/168.html" title="Last updated on May 22, 2025, 1:41 PM UTC (a3a03ef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/168/3f53acb...apasel422:a3a03ef.html" title="Last updated on May 22, 2025, 1:41 PM UTC (a3a03ef)">Diff</a>