### PR TITLE
Return a promise from the measureConversion method steps

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1266,11 +1266,15 @@ API is [[#opt-out|disabled]].
 
 ## Measure Conversion Algorithm ## {#measure-conversion-api-operation}
 
+The <a method for=PrivateAttribution>measureConversion()</a> method completes
+asynchronously, queuing work on the <dfn>Private Attribution [=task source=]</dfn>.
+
 <div algorithm>
 The <dfn method for=PrivateAttribution>measureConversion(|options|)</dfn> method steps are:
 
 <!-- TODO: Check the {{PermissionPolicy/measure-conversion}} policy. -->
 
+1.  Let |realm| be [=this=]'s [=relevant realm=].
 1.  Let |settings| be [=this=]'s [=relevant settings object=].
 1.  Collect the implicit API inputs from |settings|:
     1.  Let |now| be |settings|' [=environment settings object/current wall time=].
@@ -1286,33 +1290,37 @@ The <dfn method for=PrivateAttribution>measureConversion(|options|)</dfn> method
 1. Validate |options|:
     1.  If <a attribute for=PrivateAttribution>aggregationServices</a> does not [=map/exist|contain=]
         an [=map/entry=] with a [=map/key=] of |options|.{{PrivateAttributionConversionOptions/aggregationService}},
-        throw a {{ReferenceError}}.
+        return [=a promise rejected with=] a {{ReferenceError}} in |realm|.
     1.  If |options|.{{PrivateAttributionConversionOptions/epsilon}}
         is less than or equal to 0 or is greater than 4294,
-        throw a {{RangeError}}.
+        return [=a promise rejected with=] a {{RangeError}} in |realm|.
     1.  If |options|.{{PrivateAttributionConversionOptions/histogramSize}}
         is 0 or greater than an [=implementation-defined=] maximum value,
-        throw a {{RangeError}}.
+        return [=a promise rejected with=] a {{RangeError}} in |realm|.
     1.  Switch on the value of <a dict-member for=PrivateAttributionConversionOptions>logic</a>:
         <dl class="switch">
             :   <a enum-value for=PrivateAttributionLogic>"last-touch"</a>
             ::  Perform the following steps:
                 1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a> is 0,
-                    throw a {{RangeError}}.
+                    return [=a promise rejected with=] a {{RangeError}} in |realm|.
                 1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a>
                     is greater than <a dict-member for=PrivateAttributionConversionOptions>maxValue</a>,
-                    throw a {{RangeError}}.
+                    return [=a promise rejected with=] a {{RangeError}} in |realm|.
         </dl>
     1. If |options|.{{PrivateAttributionConversionOptions/lookbackDays}} is 0,
-        throw a {{RangeError}}.
-1.  Let |report| be the result of invoking [=create an all-zero histogram=] with
-    |options|.{{PrivateAttributionConversionOptions/histogramSize}}.
-1.  If the Private Attribution API is [[#opt-out|enabled]], set |report| to the
-    result of [=do attribution and fill a histogram=] with |options|,
-    |topLevelSite|, and |now|.
-1. Let |encryptedReport| be the result of encrypting |report|.
-<!-- TODO: Define "encrypting" -->
-1. Return |encryptedReport|.
+        return [=a promise rejected with=] a {{RangeError}} in |realm|.
+1.  Let |promise| be [=a new promise=] in |realm|.
+1.  Run the following steps [=in parallel=]:
+     1.  Let |report| be the result of invoking [=create an all-zero histogram=] with
+         |options|.{{PrivateAttributionConversionOptions/histogramSize}}.
+     1.  If the Private Attribution API is [[#opt-out|enabled]], set |report| to the
+         result of [=do attribution and fill a histogram=] with |options|,
+         |topLevelSite|, and |now|.
+     1.  Let |encryptedReport| be the result of encrypting |report|.
+     <!-- TODO: Define "encrypting" -->
+     1.  [=Queue a task=] on the [=Private Attribution task source=] to
+         [=resolve=] |promise| with |encryptedReport|.
+1. Return |promise|.
 
 </div>
 


### PR DESCRIPTION
Based on the example in https://webidl.spec.whatwg.org/#promise-example-validatedDelay.

Fixes #170


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/171.html" title="Last updated on May 22, 2025, 1:38 PM UTC (4dc7e43)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/171/3f53acb...apasel422:4dc7e43.html" title="Last updated on May 22, 2025, 1:38 PM UTC (4dc7e43)">Diff</a>