### PR TITLE
Use SyntaxError DOMException rather than JS SyntaxError

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1244,7 +1244,7 @@ The <dfn method for=PrivateAttribution>saveImpression(|options|)</dfn> method st
     1.  Let |conversionSites| be the [=set=] that is the result
         of invoking [=parse a site=]
         for each value in |options|.{{PrivateAttributionImpressionOptions/conversionSites}}.
-    1.  If any result in |conversionSites| is failure, return {{SyntaxError}}.
+    1.  If any result in |conversionSites| is failure, throw a {{"SyntaxError"}} {{DOMException}}.
 1.  If the Private Attribution API is [[#opt-out|disabled]], return.
 1.  Construct |impression| as a [=impression|saved impression=] comprising:
     *   [=impression/Match Value=] set to


### PR DESCRIPTION
Per the note at https://webidl.spec.whatwg.org/#idl-DOMException-error-names.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/177.html" title="Last updated on May 27, 2025, 1:26 PM UTC (86ed818)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/177/1ab0fc2...apasel422:86ed818.html" title="Last updated on May 27, 2025, 1:26 PM UTC (86ed818)">Diff</a>