### PR TITLE
Resolve measureConversion promise with correct type

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1328,8 +1328,11 @@ The <dfn method for=PrivateAttribution>measureConversion(|options|)</dfn> method
          |topLevelSite|, and |now|.
      1.  Let |encryptedReport| be the result of encrypting |report|.
      <!-- TODO: Define "encrypting" -->
+     1.  Let |result| be a {{PrivateAttributionConversionResult}} with the following items:
+          : {{PrivateAttributionConversionResult/report}}
+          :: |encryptedReport|
      1.  [=Queue a task=] on the [=Private Attribution task source=] to
-         [=resolve=] |promise| with |encryptedReport|.
+         [=resolve=] |promise| with |result|.
 1. Return |promise|.
 
 </div>


### PR DESCRIPTION
Per its WebIDL definition, it returns a dictionary containing the encrypted report, rather than the report itself.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/181.html" title="Last updated on May 28, 2025, 12:45 PM UTC (ff18be6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/181/82c2aed...apasel422:ff18be6.html" title="Last updated on May 28, 2025, 12:45 PM UTC (ff18be6)">Diff</a>