### PR TITLE
Default impression lifetime consistently in JS and HTTP APIs

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -628,7 +628,6 @@ The arguments to <a method for=PrivateAttribution>saveImpression()</a> are as fo
   <dd>
     A positive "time to live" (in days) after which the [=impression=] can no
     longer receive attribution.
-    If not specified, the default is 30 days.
     The [=user agent=] should impose an upper limit on the lifetime,
     and silently reduce the value specified here if it exceeds that limit.
   </dd>
@@ -1523,7 +1522,7 @@ the {{PrivateAttributionImpressionOptions}} dictionary passed to
   <dd>
     Value of <a dict-member for=PrivateAttributionImpressionOptions>lifetimeDays</a>,
     a positive [=structured header/integer=]. This key is optional.
-    If not supplied, an [=implementation-defined=] value is saved for [=impression/Lifetime=].
+    If not supplied, 30 days is saved for [=impression/Lifetime=].
   </dd>
 </dl>
 


### PR DESCRIPTION
Per the WebIDL definition, the JS API defaults to 30 days, rather than an implementation-defined value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/182.html" title="Last updated on May 28, 2025, 12:57 PM UTC (9d815ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/182/82c2aed...apasel422:9d815ee.html" title="Last updated on May 28, 2025, 12:57 PM UTC (9d815ee)">Diff</a>