### PR TITLE
Clarify options field accesses in measureConversion method

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1307,14 +1307,14 @@ The <dfn method for=PrivateAttribution>measureConversion(|options|)</dfn> method
     1.  If |options|.{{PrivateAttributionConversionOptions/histogramSize}}
         is 0 or greater than an [=implementation-defined=] maximum value,
         return [=a promise rejected with=] a {{RangeError}} in |realm|.
-    1.  Switch on the value of <a dict-member for=PrivateAttributionConversionOptions>logic</a>:
+    1.  Switch on the value of |options|.{{PrivateAttributionConversionOptions/logic}}:
         <dl class="switch">
             :   <a enum-value for=PrivateAttributionLogic>"last-touch"</a>
             ::  Perform the following steps:
-                1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a> is 0,
+                1.  If |options|.{{PrivateAttributionConversionOptions/value}} is 0,
                     return [=a promise rejected with=] a {{RangeError}} in |realm|.
-                1.  If <a dict-member for=PrivateAttributionConversionOptions>value</a>
-                    is greater than <a dict-member for=PrivateAttributionConversionOptions>maxValue</a>,
+                1.  If |options|.{{PrivateAttributionConversionOptions/value}}
+                    is greater than |options|.{{PrivateAttributionConversionOptions/maxValue}},
                     return [=a promise rejected with=] a {{RangeError}} in |realm|.
         </dl>
     1. If |options|.{{PrivateAttributionConversionOptions/lookbackDays}} is 0,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/184.html" title="Last updated on May 28, 2025, 2:55 PM UTC (7e30fbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/184/82c2aed...apasel422:7e30fbd.html" title="Last updated on May 28, 2025, 2:55 PM UTC (7e30fbd)">Diff</a>