### PR TITLE
Exclude expired impressions from common matching logic

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1414,8 +1414,8 @@ To perform <dfn>common matching logic</dfn>, given
 1.  [=set/iterate|For each=] |impression| in the [=impression store=] for the |epoch|:
 <!-- TODO: Clarify "for the |epoch|" -->
 
-    1.  If |now| - |impression|'s [=impression/lifetime=] is after |impression|'s
-        [=impression/timestamp=], [=iteration/continue=].
+    1.  If |now| is after |impression|'s [=impression/timestamp=] plus |impression|'s
+        [=impression/lifetime=], [=iteration/continue=].
 
     1.  If |now| - |lookbackDays| is after |impression|'s [=impression/timestamp=],
         [=iteration/continue=].


### PR DESCRIPTION
Fixes #185


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/186.html" title="Last updated on May 29, 2025, 12:05 PM UTC (a972958)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/186/82c2aed...apasel422:a972958.html" title="Last updated on May 29, 2025, 12:05 PM UTC (a972958)">Diff</a>