### PR TITLE
Reject impressions with histogramIndex >= maximum histogram size

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1364,6 +1364,8 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
     throw a {{RangeError}}.
 1.  If |options|.{{AttributionConversionOptions/histogramSize}}
     is 0 or greater than the [=implementation-defined=] <dfn>maximum histogram size</dfn>,
+    or is greater than the <dfn ignore>maximum aggregation-service histogram size</dfn>,
+    if any, for |options|.{{AttributionConversionOptions/aggregationService}},
     throw a {{RangeError}}.
 1.  Switch on the value of |options|.{{AttributionConversionOptions/logic}}:
     <dl class="switch">


### PR DESCRIPTION
Since they will never be able to fill a histogram.

Fixes #197


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/198.html" title="Last updated on Jun 23, 2025, 11:58 AM UTC (6159fcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/198/e6966b1...apasel422:6159fcd.html" title="Last updated on Jun 23, 2025, 11:58 AM UTC (6159fcd)">Diff</a>