### PR TITLE
Define epoch matching

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1481,14 +1481,21 @@ To perform <dfn>common matching logic</dfn>, given
 
 1.  Let |matching| be an [=set/is empty|empty=] [=set=].
 
-1.  If the number of [=days=] since the end of |epoch| exceeds |options|'
-    [=validated conversion options/lookback=], return |matching|.
+1.  Let |earliestEpoch| be the result of calling [=get the current epoch=],
+    passing |topLevelSite| and (|now| − |options|' [=validated conversion options/lookback=]).
 
-1.  [=set/iterate|For each=] |impression| in the [=impression store=] for the |epoch|:
-<!-- TODO: Clarify "for the |epoch|" -->
+1.  If |earliestEpoch| is greater than |epoch|, return |matching|.
 
-    1.  If |now| is after |impression|'s [=impression/timestamp=] plus |impression|'s
-        [=impression/lifetime=], [=iteration/continue=].
+1.  [=set/iterate|For each=] |impression| in the [=impression store=]:
+
+    1.  Let |impressionEpoch| be the result of calling [=get the current epoch=],
+        passing |topLevelSite| and |impression|'s [=impression/timestamp=].
+
+    1.  If |impressionEpoch| is not equal to |epoch|, [=iteration/continue=].
+
+    1.  If |now| is after |impression|'s [=impression/timestamp=]
+        plus |impression|'s [=impression/lifetime=],
+        [=iteration/continue=].
 
     1.  If |now| is after |impression|'s [=impression/timestamp=] plus |options|' [=validated conversion options/lookback=],
         [=iteration/continue=].


### PR DESCRIPTION
I considered doing this in the way that the issue suggested, but when I got down to it, that would require the definition of a new method to get epoch start and end times.  This does it based on epoch indices.

In short, this iterates all impressions in the store, gets the epoch index that corresponds to the timestamp, and skips any that are not equal to the epoch we're looking at.

I've tweaked the short circuit on lookback to also use epoch index.  It checks whether the epoch index for now - lookback is less than the current epoch.

In practice, this would be horribly inefficient. You would definitely not want to implement things this way.  The upside is that this is fairly straightforward to specify and understand.

Closes #207.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/pull/209.html" title="Last updated on Jun 20, 2025, 12:26 AM UTC (8adceef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/209/b9a9fd0...8adceef.html" title="Last updated on Jun 20, 2025, 12:26 AM UTC (8adceef)">Diff</a>