### PR TITLE
Permit implementation-defined maximum sizes on list inputs

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1354,6 +1354,10 @@ The <dfn method for=Attribution>saveImpression(|options|)</dfn> method steps are
         for each value in |options|.{{AttributionImpressionOptions/conversionSites}}.
     1.  If any result in |conversionSites| is failure, return
         [=a promise rejected with=] a {{"SyntaxError"}} {{DOMException}} in |realm|.
+    1.  If the [=list/size=] of
+        |options|.{{AttributionImpressionOptions/conversionCallers}} is
+        greater than an [=implementation-defined=] maximum value, return
+        [=a promise rejected with=] a {{RangeError}} in |realm|.
     1.  Let |conversionCallers| be the [=set=] that is the result
         of invoking [=parse a site=]
         for each value in |options|.{{AttributionImpressionOptions/conversionCallers}}.
@@ -1482,12 +1486,21 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
 1.  Let |lookback| be |options|.{{AttributionConversionOptions/lookbackDays}} [=days=]
     if it [=map/exists=], the [=implementation-defined=] maximum otherwise.
 1.  If |lookback| is 0 [=days=], throw a {{RangeError}}.
+1.  If the [=list/size=] of
+    |options|.{{AttributionConversionOptions/matchValue}} is
+    greater than an [=implementation-defined=] maximum value, throw a {{RangeError}}.
 1.  Let |matchValue| be the result of running [=set/create|creating a set=] with
     |options|.{{AttributionConversionOptions/matchValue}}.
+1.  If the [=list/size=] of
+    |options|.{{AttributionConversionOptions/impressionSites}} is
+    greater than an [=implementation-defined=] maximum value, throw a {{RangeError}}.
 1.  Let |impressionSites| be the [=set=] that is the result
     of invoking [=parse a site=]
     for each value in |options|.{{AttributionConversionOptions/impressionSites}}.
 1.  If any result in |impressionSites| is failure, throw a {{"SyntaxError"}} {{DOMException}}.
+1.  If the [=list/size=] of
+    |options|.{{AttributionConversionOptions/impressionCallers}} is
+    greater than an [=implementation-defined=] maximum value, throw a {{RangeError}}.
 1.  Let |impressionCallers| be the [=set=] that is the result
     of invoking [=parse a site=]
     for each value in |options|.{{AttributionConversionOptions/impressionCallers}}.


### PR DESCRIPTION
Without commiting to minimum values for those maximums.

- `AttributionImpressionOptions.conversionCallers`
- `AttributionConversionOptions.matchValue`
- `AttributionConversionOptions.impressionSites`
- `AttributionConversionOptions.impressionCallers`

Part of #174


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/213.html" title="Last updated on Jun 25, 2025, 4:02 PM UTC (a5827af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/213/cde2cbc...apasel422:a5827af.html" title="Last updated on Jun 25, 2025, 4:02 PM UTC (a5827af)">Diff</a>