### PR TITLE
Return final credit assignments from fairly-allocate-credit algorithm

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1705,7 +1705,7 @@ To <dfn>fairly allocate credit</dfn>, given a [=list=] of doubles |credit| and a
 1.  Let |rawNormalizedCredit| be a new [=list=].
 1.  Let |normalizedCredit| be a new [=list=].
 1.  [=list/iterate|For each=] |item| of |credit|:
-      1. Let |rawNormalized| be |item| / |sumCredit| * |value|.
+      1. Let |rawNormalized| be |value| * |item| / |sumCredit|.
       1. [=list/Append=] |rawNormalized| to |rawNormalizedCredit|.
       1. Let |normalized| be |rawNormalized| rounded towards positive Infinity and converted to an integer.
       1. [=list/Append=] |normalized| to |normalizedCredit|.


### PR DESCRIPTION
Previously, the value factor was divided out during normalization, meaning that the histogram consisted of a total value of 1, regardless of the configured value.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/223.html" title="Last updated on Jul 15, 2025, 6:59 PM UTC (70ec146)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/223/cc56baa...apasel422:70ec146.html" title="Last updated on Jul 15, 2025, 6:59 PM UTC (70ec146)">Diff</a>