### PR TITLE
Introduce constant for max epsilon

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1123,7 +1123,8 @@ in units [=microepsilons=].
 A <dfn>microepsilon</dfn> is one-millionth of the unitary epsilon value
 used in differential privacy [[DP]].
 
-<p class=note>The choice of a 32-bit integer restricts the setting of epsilon to be less than 4295.
+<p class=note>The choice of a 32-bit integer restricts the setting of epsilon to
+be less than or equal to the <dfn>max epsilon</dfn> of 4294.
 This <span class=allow-2119>should</span> be more than sufficient for implementations.
 
 A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items:
@@ -1157,7 +1158,7 @@ and integer |globalSensitivity|:
 
 1.  Let |deductionFp| be |epsilon| * |sensitivity| / |globalSensitivity|.
 
-1.  If |deductionFp| is negative or greater than 4294,
+1.  If |deductionFp| is negative or greater than [=max epsilon=],
     [=map/set|set=] the value of |key| in the [=privacy budget store=] to 0
     and return false.
 
@@ -1496,7 +1497,7 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
     from {{AttributionAggregationServices}},
     given |options|.{{AttributionConversionOptions/aggregationService}}.
 1.  If |options|.{{AttributionConversionOptions/epsilon}}
-    is less than or equal to 0 or is greater than 4294,
+    is less than or equal to 0 or is greater than [=max epsilon=],
     throw a {{RangeError}}.
 1.  If |options|.{{AttributionConversionOptions/histogramSize}}
     is 0 or greater than the [=implementation-defined=] <dfn>maximum histogram size</dfn>,

--- a/api.bs
+++ b/api.bs
@@ -1158,7 +1158,7 @@ and integer |globalSensitivity|:
 
 1.  Let |deductionFp| be |epsilon| * |sensitivity| / |globalSensitivity|.
 
-1.  If |deductionFp| is negative or greater than [=max epsilon=],
+1.  If |deductionFp| is negative or greater than [=maximum epsilon=],
     [=map/set|set=] the value of |key| in the [=privacy budget store=] to 0
     and return false.
 
@@ -1497,7 +1497,7 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
     from {{AttributionAggregationServices}},
     given |options|.{{AttributionConversionOptions/aggregationService}}.
 1.  If |options|.{{AttributionConversionOptions/epsilon}}
-    is less than or equal to 0 or is greater than [=max epsilon=],
+    is less than or equal to 0 or is greater than [=maximum epsilon=],
     throw a {{RangeError}}.
 1.  If |options|.{{AttributionConversionOptions/histogramSize}}
     is 0 or greater than the [=implementation-defined=] <dfn>maximum histogram size</dfn>,

--- a/api.bs
+++ b/api.bs
@@ -1124,7 +1124,7 @@ A <dfn>microepsilon</dfn> is one-millionth of the unitary epsilon value
 used in differential privacy [[DP]].
 
 <p class=note>The choice of a 32-bit integer restricts the setting of epsilon to
-be less than or equal to the <dfn>max epsilon</dfn> of 4294.
+be less than or equal to the <dfn>maximum epsilon</dfn> of 4294.
 This <span class=allow-2119>should</span> be more than sufficient for implementations.
 
 A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items:


### PR DESCRIPTION
For ease of reference.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/229.html" title="Last updated on Aug 1, 2025, 12:00 PM UTC (5982dd9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/ppa/229/260bfe4...apasel422:5982dd9.html" title="Last updated on Aug 1, 2025, 12:00 PM UTC (5982dd9)">Diff</a>