### PR TITLE
Add single epoch optimization

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1143,7 +1143,7 @@ given a [=privacy budget key=] |key|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|, and
-integer |l1Norm|:
+integer |attributedValueForSingleEpochOpt|:
 
 1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
     its value of |key| to be a [=user agent=]-defined value,
@@ -1157,13 +1157,13 @@ integer |l1Norm|:
 1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
     in the [=privacy budget store=].
 
-1.  Let |singleEpochQuery| be true if |l1Norm| is non-null, false otherwise.
+1.  Let |singleEpochQuery| be true if |attributedValueForSingleEpochOpt| is non-null, false otherwise.
 
-1.  Let |reportGlobalSensitivity| be |l1Norm| if |singleEpochQuery| is true, 2 * |value| otherwise.
+1.  Let |halfReportGlobalSensitivity| be |attributedValueForSingleEpochOpt|/2 if |singleEpochQuery| is true, |value| otherwise.
 
-1.  Let |noiseScale| be |maxValue| / |epsilon|.
+1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
 
-1.  Let |deductionFp| be |reportGlobalSensitivity| / |noiseScale|.
+1.  Let |deductionFp| be |halfReportGlobalSensitivity| / |noiseScale|.
 
 <p class=note>Single epoch attributions do not cause any cascading effects across epochs,
 so they do not need to consume double the budget. The deduction here is assuming Laplace


### PR DESCRIPTION
This fixes #78 and partially addresses #212 . The algorithm uses the configured lookback window to determine automatically if the attribution is only considering impressions from the current epoch. If so, budget deduction is altered by considering the report's sensitivity to be `|l1Norm|` rather than `2 * |value|`.

In both cases, we assume that the noise scale for Laplace noise is `lambda = |maxValue| / |epsilon|.

Note: An alternative considered was to add a new option to the API to query epochs and apply the optimization if only a single epoch was chosen, but _using_ that API seems difficult, and at a minimum requires exposing the epoch start map to all conversion sites to use it effectively. Additionally, it adds API surface bloat.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/239.html" title="Last updated on Aug 15, 2025, 6:45 PM UTC (a3d8244)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/239/12c9995...a3d8244.html" title="Last updated on Aug 15, 2025, 6:45 PM UTC (a3d8244)">Diff</a>