### PR TITLE
Merge max impression-lifetime and lookback options in simulator

### DIFF
--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -76,7 +76,6 @@ export interface Delegate {
   readonly maxConversionCallersPerImpression: number;
   readonly maxCreditSize: number;
   readonly maxLifetimeDays: number;
-  readonly maxLookbackDays: number;
   readonly maxHistogramSize: number;
   readonly privacyBudgetMicroEpsilons: number;
   readonly privacyBudgetEpoch: Temporal.Duration;
@@ -210,7 +209,7 @@ export class Backend {
     histogramSize,
     impressionSites = [],
     impressionCallers = [],
-    lookbackDays = this.#delegate.maxLookbackDays,
+    lookbackDays = this.#delegate.maxLifetimeDays,
     logic = index.DEFAULT_CONVERSION_LOGIC,
     logicOptions,
     maxValue = index.DEFAULT_CONVERSION_MAX_VALUE,
@@ -276,7 +275,7 @@ export class Backend {
     if (lookbackDays <= 0 || !Number.isInteger(lookbackDays)) {
       throw new RangeError("lookbackDays must be a positive integer");
     }
-    lookbackDays = Math.min(lookbackDays, this.#delegate.maxLookbackDays);
+    lookbackDays = Math.min(lookbackDays, this.#delegate.maxLifetimeDays);
 
     const matchValueSet = new Set<number>();
     for (const value of matchValues) {

--- a/impl/src/e2e.test.ts
+++ b/impl/src/e2e.test.ts
@@ -20,7 +20,6 @@ interface TestConfig {
   maxConversionCallersPerImpression: number;
   maxCreditSize: number;
   maxLifetimeDays: number;
-  maxLookbackDays: number;
   maxHistogramSize: number;
   privacyBudgetMicroEpsilons: number;
   privacyBudgetEpochDays: number;
@@ -95,7 +94,6 @@ function runTest(
     maxConversionCallersPerImpression: config.maxConversionCallersPerImpression,
     maxCreditSize: config.maxCreditSize,
     maxLifetimeDays: config.maxLifetimeDays,
-    maxLookbackDays: config.maxLookbackDays,
     maxHistogramSize: config.maxHistogramSize,
     privacyBudgetMicroEpsilons: config.privacyBudgetMicroEpsilons,
     privacyBudgetEpoch: days(config.privacyBudgetEpochDays),

--- a/impl/src/simulator.ts
+++ b/impl/src/simulator.ts
@@ -20,7 +20,6 @@ const backend = new Backend({
   maxConversionCallersPerImpression: 10,
   maxCreditSize: Infinity,
   maxLifetimeDays: 30,
-  maxLookbackDays: 60,
   maxHistogramSize: 100,
   privacyBudgetMicroEpsilons: 1000000,
   privacyBudgetEpoch: days(7),


### PR DESCRIPTION
Per #257:

> There is no point to having different maximum values for
these values as the smaller of the two values
will determine which saved impressions are available for conversions.