### PR TITLE
Specify structured-header integer to WebIDL conversions

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1922,17 +1922,17 @@ the {{AttributionImpressionOptions}} dictionary passed to
   <dt><dfn noexport><code>histogram-index</code></dfn></dt>
   <dd>
     Value of <a dict-member for=AttributionImpressionOptions>histogramIndex</a>,
-    a non-negative [=structured header/integer=]. This key is required.
+    an [=structured header/integer=] in the [=32-bit unsigned integer=] range. This key is required.
   </dd>
   <dt><dfn noexport><code>priority</code></dfn></dt>
   <dd>
     Value of <a dict-member for=AttributionImpressionOptions>priority</a>,
-    an [=structured header/integer=]. This key is optional.
+    an [=structured header/integer=] in the [=32-bit signed integer=] range. This key is optional.
   </dd>
   <dt><dfn noexport><code>match-value</code></dfn></dt>
   <dd>
     Value of <a dict-member for=AttributionImpressionOptions>matchValue</a>,
-    a non-negative [=structured header/integer=]. This key is optional.
+    an [=structured header/integer=] in the [=32-bit unsigned integer=] range. This key is optional.
     If not supplied, a value of 0 is saved for [=impression/Match Value=].
   </dd>
   <dt><dfn noexport><code>lifetime-days</code></dfn></dt>
@@ -1952,7 +1952,7 @@ To <dfn noexport>parse a `Save-Impression` header</dfn> given a [=header value=]
     <var ignore>field_type</var> set to "`dictionary`".
 1.  If parsing failed, return an error.
 1.  If |dict|["<code>[=save-impression/histogram-index=]</code>"] does not [=map/exist=] or
-    is not an [=structured header/integer=] or is less than 0, return an error.
+    is not an [=structured header/integer=] in the [=32-bit unsigned integer=] range, return an error.
 1.  Let |histogramIndex| be |dict|["<code>[=save-impression/histogram-index=]</code>"].
 1.  Let |conversionSites| be |dict|["<code>[=save-impression/conversion-sites=]</code>"]
     [=map/with default=] an empty [=structured header/inner list=].
@@ -1961,11 +1961,12 @@ To <dfn noexport>parse a `Save-Impression` header</dfn> given a [=header value=]
     [=map/with default=] an empty [=structured header/inner list=].
 1.  If |conversionCallers| is not an [=structured header/inner list=], or if any of |conversionCallers|' [=list/items=] is not a [=structured header/string=], return an error.
 1.  Let |matchValue| be |dict|["<code>[=save-impression/match-value=]</code>"] [=map/with default=] 0.
-1.  If |matchValue| is not an [=structured header/integer=] or is less than 0, return an error.
+1.  If |matchValue| is not an [=structured header/integer=] in the [=32-bit unsigned integer=] range, return an error.
 1.  Let |lifetimeDays| be |dict|["<code>[=save-impression/lifetime-days=]</code>"] [=map/with default=] 30.
-1.  If |lifetimeDays| is not an [=structured header/integer=] or is less than or equal to 0, return an error.
+1.  If |lifetimeDays| is not a positive [=structured header/integer=], return an error.
+1.  Clamp |lifetimeDays| to the [=32-bit unsigned integer=] range.
 1.  Let |priority| be |dict|["<code>[=save-impression/priority=]</code>"] [=map/with default=] 0.
-1.  If |priority| is not an [=structured header/integer=], return an error.
+1.  If |priority| is not an [=structured header/integer=] in the [=32-bit signed integer=] range, return an error.
 1.  Return a new {{AttributionImpressionOptions}} with the following items:
      : {{AttributionImpressionOptions/histogramIndex}}
      :: |histogramIndex|

--- a/impl/src/http.test.ts
+++ b/impl/src/http.test.ts
@@ -74,6 +74,23 @@ runTests([
   { name: "histogram-index-not-integer", input: "histogram-index=1.2" },
 
   {
+    name: "valid-histogram-index-eq-32-bit-max",
+    input: "histogram-index=4294967295",
+    expected: {
+      histogramIndex: 4294967295,
+      matchValue: 0,
+      conversionSites: [],
+      conversionCallers: [],
+      lifetimeDays: 30,
+      priority: 0,
+    },
+  },
+  {
+    name: "histogram-index-gt-32-bit-max",
+    input: "histogram-index=4294967296",
+  },
+
+  {
     name: "conversion-sites-wrong-type",
     input: "conversion-sites=a, histogram-index=1",
   },
@@ -97,6 +114,22 @@ runTests([
     name: "match-value-not-integer",
     input: "match-value=1.2, histogram-index=1",
   },
+  {
+    name: "valid-match-value-eq-32-bit-max",
+    input: "match-value=4294967295, histogram-index=1",
+    expected: {
+      histogramIndex: 1,
+      matchValue: 4294967295,
+      conversionSites: [],
+      conversionCallers: [],
+      lifetimeDays: 30,
+      priority: 0,
+    },
+  },
+  {
+    name: "match-value-gt-32-bit-max",
+    input: "match-value=4294967296, histogram-index=1",
+  },
 
   {
     name: "lifetime-days-wrong-type",
@@ -111,7 +144,51 @@ runTests([
     input: "lifetime-days=1.2, histogram-index=1",
   },
   { name: "lifetime-days-zero", input: "lifetime-days=0, histogram-index=1" },
+  {
+    name: "valid-lifetime-days-maximal-clamped",
+    input: "lifetime-days=999999999999999, histogram-index=1",
+    expected: {
+      histogramIndex: 1,
+      matchValue: 0,
+      conversionSites: [],
+      conversionCallers: [],
+      lifetimeDays: 4294967295,
+      priority: 0,
+    },
+  },
 
   { name: "priority-wrong-type", input: "priority=a, histogram-index=1" },
   { name: "priority-not-integer", input: "priority=1.2, histogram-index=1" },
+  {
+    name: "valid-priority-eq-32-bit-max",
+    input: "priority=2147483647, histogram-index=1",
+    expected: {
+      histogramIndex: 1,
+      matchValue: 0,
+      conversionSites: [],
+      conversionCallers: [],
+      lifetimeDays: 30,
+      priority: 2147483647,
+    },
+  },
+  {
+    name: "valid-priority-eq-32-bit-min",
+    input: "priority=-2147483648, histogram-index=1",
+    expected: {
+      histogramIndex: 1,
+      matchValue: 0,
+      conversionSites: [],
+      conversionCallers: [],
+      lifetimeDays: 30,
+      priority: -2147483648,
+    },
+  },
+  {
+    name: "priority-gt-32-bit-max",
+    input: "priority=2147483648, histogram-index=1",
+  },
+  {
+    name: "priority-lt-32-bit-min",
+    input: "priority=-2147483649, histogram-index=1",
+  },
 ]);


### PR DESCRIPTION
Fixes #281.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/282.html" title="Last updated on Sep 16, 2025, 3:13 PM UTC (1fde755)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/282/231e32b...apasel422:1fde755.html" title="Last updated on Sep 16, 2025, 3:13 PM UTC (1fde755)">Diff</a>