### PR TITLE
Replace DOMString with AttributionAggregationProtocol

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -510,7 +510,7 @@ and impressions are not scoped to a single aggregation service.
 enum AttributionAggregationProtocol { "dap-15-histogram", "tee-00" };
 
 dictionary AttributionAggregationService {
-  required DOMString protocol;
+  required AttributionAggregationProtocol protocol;
 };
 
 [SecureContext, Exposed=Window]


### PR DESCRIPTION
To make it clear that the AttributionAggregationService.protocol field always contains one of these values, which the rest of the specification already assumes/enforces.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/305.html" title="Last updated on Nov 5, 2025, 2:50 PM UTC (af509b9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/305/2c38eb6...apasel422:af509b9.html" title="Last updated on Nov 5, 2025, 2:50 PM UTC (af509b9)">Diff</a>