### PR TITLE
[RFC] Safety limits

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1188,10 +1188,13 @@ nullable integer |l1Norm|:
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
 
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
-    with |key|, |deduction|, and |impressionSiteDeduction|
+    with |key|, |deduction|, |impressionSites|, and |impressionSiteDeduction|
     is false, return false.
 
 1.  All budget checks passed, so perform the deductions atomically:
+
+    1.  If the [=privacy budget store=] does not [=map/contain=] |key|,
+        [=map/set=] its value to the [=per-site privacy budget=].
 
     1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
         in the [=privacy budget store=].

--- a/api.bs
+++ b/api.bs
@@ -1142,7 +1142,7 @@ A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items
 To <dfn>deduct privacy and safety budgets</dfn>
 given a [=privacy budget key=] |key|,
 [=epoch index=] |epoch|,
-a [=map=] |impressionsBySite| from [=impression sites=] to [=sets=] of [=impressions=],
+|impressions| as a set of [=impressions=],
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|, and

--- a/api.bs
+++ b/api.bs
@@ -1171,7 +1171,7 @@ nullable integer |l1Norm|:
 
 1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
-1.  Let |impressionsSites| be a new [=set=].
+1.  Let |impressionSites| be a new [=set=].
 
 1.  [=set/iterate|For each=] |impression| in |impressions|:
 
@@ -1179,12 +1179,10 @@ nullable integer |l1Norm|:
 
     1.  [=set/append=] |impressionSite| to |impressionSites|.
 
-1.  Let |numberImpressionSites| be the [=set/size|number of impression sites=] in |impressionsSites|.
-
 1.  Let |isSingleEpoch| be true if |l1Norm| is non-null, false otherwise.
 
 1.  Let |impressionSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
-    with |numberImpressionSites|, |deduction|, |value|, |maxValue|, |epsilon|, and |isSingleEpoch|.
+    with |impressionSites|, |deduction|, |value|, |maxValue|, |epsilon|, and |isSingleEpoch|.
 
 <p class=issue>TODO: Additional work to specify
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
@@ -1263,7 +1261,7 @@ a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
 
 <div algorithm>
 To <dfn>compute impression site deductions</dfn>
-given an integer |numberImpressionSites|,
+given an set |impressionSites| of [=impression sites=],
 integer |deduction|,
 integer |value|,
 integer |maxValue|,
@@ -1279,6 +1277,8 @@ boolean |isSingleEpoch|:
 1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
 
 1.  Let |globalDeduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
+
+1.  Let |numberImpressionSites| be the [=set/size|number of impression sites=] in |impressionSites|.
 
 1.  [=map/iterate|For each=] |impressionSite| in |impressionsBySite|:
 

--- a/api.bs
+++ b/api.bs
@@ -1171,21 +1171,20 @@ nullable integer |l1Norm|:
 
 1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
-1.  Let |impressionsBySite| be a new [=map=].
+1.  Let |impressionsSites| be a new [=set=].
 
 1.  [=set/iterate|For each=] |impression| in |impressions|:
 
     1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-    1.  If |impressionsBySite| does not [=map/contain=] |impressionSite|,
-        [=map/set=] |impressionsBySite|\[|impressionSite|] to an empty [=set=].
+    1.  [=set/append=] |impressionSite| to |impressionSites|.
 
-    1.  [=set/Append=] |impression| to |impressionsBySite|\[|impressionSite|].
+1.  Let |numberImpressionSites| be the [=set/size|number of impression sites=] in |impressionsSites|.
 
-1. Let |isSingleEpoch| be true if |l1Norm| is non-null, false otherwise.
+1.  Let |isSingleEpoch| be true if |l1Norm| is non-null, false otherwise.
 
 1.  Let |impressionSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
-    with |impressionsBySite|, |deduction|, |value|, |maxValue|, |epsilon|, and |isSingleEpoch|.
+    with |numberImpressionSites|, |deduction|, |value|, |maxValue|, |epsilon|, and |isSingleEpoch|.
 
 <p class=issue>TODO: Additional work to specify
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
@@ -1264,7 +1263,7 @@ a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
 
 <div algorithm>
 To <dfn>compute impression site deductions</dfn>
-given a [=map=] |impressionsBySite| from [=impression sites=] to [=sets=] of [=impressions=],
+given an integer |numberImpressionSites|,
 integer |deduction|,
 integer |value|,
 integer |maxValue|,
@@ -1272,8 +1271,6 @@ integer |maxValue|,
 boolean |isSingleEpoch|:
 
 1.  Let |impressionSiteDeductions| be a new [=map=].
-
-1.  Let |numberImpressionSites| be the [=map/size|number of impression sites=] in |impressionsBySite|.
 
 1.  Let |sensitivity| be 2 * |value|.
 

--- a/api.bs
+++ b/api.bs
@@ -1188,7 +1188,7 @@ nullable integer |l1Norm|:
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
 
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
-    with |key|, |deduction|, and |impressionSiteDeductions|
+    with |key|, |deduction|, and |impressionSiteDeduction|
     is false, return false.
 
 1.  All budget checks passed, so perform the deductions atomically:
@@ -1243,7 +1243,7 @@ and a set |impressionSites| of [=impression sites=],:
         whose items are |epoch| and |impressionSite|.
 
     1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|
-        and |siteDeduction| is greater than the [=impression site quota per epoch=], return false.
+        and |impressionSiteDeduction| is greater than the [=impression site quota per epoch=], return false.
 
     1.  If [=map/contains=] |impressionQuotaKey| and |impressionSiteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
             return false.
@@ -1271,18 +1271,16 @@ boolean |isSingleEpoch|:
 
 1.  Let |numberImpressionSites| be the [=set/size|number of impression sites=] in |impressionSites|.
 
-1.  [=map/iterate|For each=] |impressionSite| in |impressionSites|:
+1.  If |isSingleEpoch| is true and |numberImpressionSites| is 1:
 
-    1.  If |isSingleEpoch| is true and |numberImpressionSites| is 1:
+    1.  Return |deduction|.
 
-        1.  Return |deduction|.
+1.  Otherwise:
 
-    1.  Otherwise:
-
-        <p class=note>In this case we need to use the global sensitivity which is the value of |deduction| only in the multi-epoch case;
+    <p class=note>In this case we need to use the global sensitivity which is the value of |deduction| only in the multi-epoch case;
         so we need to recompute it in case we are in the single epoch but multiple impression sites case.
 
-        1.  Return |globalDeduction|.
+    1.  Return |globalDeduction|.
 
 </div>
 
@@ -2165,9 +2163,9 @@ is hard and therefore TBD.
 <dfn>Privacy Parameters</dfn>: [=User agents=] configure the [=privacy budget=] and [=safety limits=] by defining values
 for the following:
 
-*   The per-[=site=] [=privacy budget=] (&epsilon;<sub>site</sub>) within the range of: TBD
+*   The <dfn>per-site privacy budget</dfn> (&epsilon;<sub>site</sub>) within the range of: TBD
 
-*   The <dfn>global budget per epoch</dfn> (&epsilon;<sub>global</sub>) which is
+*   The <dfn>global privacy budget per epoch</dfn> (&epsilon;<sub>global</sub>) which is
     the maximum privacy budget available across all [=sites=] per [=epoch=],
     specified in [=microepsilons=].
     Implementations [=must=] set this value as a multiple of

--- a/api.bs
+++ b/api.bs
@@ -1097,12 +1097,6 @@ that are used to manage the expenditure of [=privacy budgets=]:
 *   The [=impression site quota store=] records the state
     of per-[=impression site=] and per-[=epoch=] quota [=privacy budgets=].
 
-*   The [=conversion site quota store=] records the state
-    of per-[=conversion site=] and per-[=epoch=] quota [=privacy budgets=].
-
-*   The [=user action context store=] records which [=sites=]
-    have accessed quota [=privacy budgets=] within the current [=user action context=].
-
 <p class=note>
 Like the [=impression store=],
 the [=privacy budget store=] and related stores do not use a [=storage key=].
@@ -1205,15 +1199,6 @@ nullable integer |l1Norm|:
     1.  If |deduction| is greater than [=global privacy budget store=]\[|epoch|],
         return false.
 
-    1.  Let |convQuotaKey| be a [=conversion site quota key=]
-        whose items are |epoch| and |conversionSite|.
-
-    1.  If the [=conversion site quota store=] does not [=map/contain=] |convQuotaKey|,
-        [=map/set=] its value to the [=conversion site quota per epoch=].
-
-    1.  If |deduction| is greater than [=conversion site quota store=]\[|convQuotaKey|],
-        return false.
-
     1.  [=map/iterate|For each=] |impSite| → |siteDeduction| in |impSiteDeductions|:
 
         1.  Let |impQuotaKey| be an [=impression site quota key=]
@@ -1231,8 +1216,6 @@ nullable integer |l1Norm|:
         to |currentValue| − |deduction|.
 
     1.  Decrement [=global privacy budget store=]\[|epoch|] by |deduction|.
-
-    1.  Decrement [=conversion site quota store=]\[|convQuotaKey|] by |deduction|.
 
     1.  [=map/iterate|For each=] |impSite| → |siteDeduction| in |impSiteDeductions|:
 
@@ -1288,158 +1271,42 @@ from enabling excessive budget
 that could be maliciously triggered.
 
 
-### Conversion Site Quota Store ### {#s-conversion-site-quota-store}
+### Attribution API Activation ### {#s-api-activation}
 
-The <dfn>conversion site quota store</dfn> is a [=map=] whose keys are
-[=conversion site quota keys=] and whose values are [=32-bit unsigned integers=]
-in units of [=microepsilons=].
+The Attribution API requires user activation to prevent abuse.
+A <dfn>global attribution API flag</dfn> is associated with each {{Window}} object.
+This flag is initially false.
 
-A <dfn>conversion site quota key</dfn> is a [=tuple=] consisting of the following items:
+The API can be invoked if either:
+1.  The [=global attribution API flag=] for the current {{Window}} is true, or
+2.  The current {{Window}} has [=transient activation=] that can be [=consume user activation|consumed=].
 
-<dl dfn-for="conversion site quota key">
-: <dfn ignore>epoch index</dfn>
-:: An [=epoch index=]
-: <dfn ignore>conversion site</dfn>
-:: A [=conversion site=]
+When the API is successfully invoked:
+1.  If [=transient activation=] was consumed, set the [=global attribution API flag=] to true.
 
-</dl>
+<p class=note>This approach allows a single user action to enable multiple
+API invocations within the same page session, while still requiring
+an initial user gesture to activate the API.
 
-The [=conversion site quota store=] limits the amount of "flow"
-(privacy budget consumed by reports)
-that any single [=conversion site=] can trigger in an [=epoch=].
-This constrains the budget that can be drawn by a [=conversion site=],
-limiting its ability to rapidly deplete the [=global privacy budget=].
-
-
-### User Action Context Store ### {#s-user-action-context-store}
-
-The <dfn>user action context store</dfn> is a [=map=] keyed by [=user action contexts=]
-and containing values that are [=user action context entries=].
-
-A <dfn>user action context</dfn> is an identifier
-for a sequence of API invocations
-that are associated with a single intentional user action,
-such as a navigation or click.
-
-A <dfn>user action context entry</dfn> is a [=struct=] with the following fields:
-
-<dl dfn-for="user action context entry">
-: <dfn>Allowed Impression Sites</dfn>
-:: A [=set=] of [=impression sites=] that have been permitted
-   to save [=impressions=] within this [=user action context=].
-: <dfn>Impression Site Counter</dfn>
-:: A non-negative integer representing the remaining number of
-   new [=impression sites=] that may save [=impressions=]
-   within this [=user action context=].
-   Initialized to an [=implementation-defined=] <dfn>impression site count cap</dfn>.
-: <dfn>Allowed Conversion Sites</dfn>
-:: A [=map=] keyed by [=epoch index=] and containing values that are [=sets=]
-   of [=conversion sites=] that have been permitted to measure [=conversions=]
-   within this [=user action context=] for that [=epoch=].
-: <dfn>Conversion Site Counters</dfn>
-:: A [=map=] keyed by [=epoch index=] and containing values that are
-   non-negative integers representing the remaining number of
-   new [=conversion sites=] that may measure [=conversions=]
-   within this [=user action context=] for that [=epoch=].
-   Each counter is initialized to an [=implementation-defined=] <dfn>conversion site count cap</dfn>.
-</dl>
-
-The [=user action context store=] tracks which [=sites=]
-have accessed quota [=privacy budgets=]
-(either [=impression site quota store|impression site quotas=]
-or [=conversion site quota store|conversion site quotas=])
-within the current [=user action context=].
-This enables enforcement of site count caps,
-limiting the number of distinct sites that can participate
-in attribution within a single user action.
-
-<p class=note>A [=user action context=] typically corresponds to
-a top-level navigation or other substantial user interaction.
-[=User agents=] determine when a new [=user action context=] begins
-based on their understanding of intentional user actions.
+<p class=issue>TODO: Define how long the [=global attribution API flag=] remains true
+and under what conditions it should be reset (e.g., navigation, page lifecycle events).
 
 <div algorithm>
-To get the <dfn>current user action context</dfn>,
-returning a [=user action context=]:
-
-1.  If the [=user agent=] has an active [=user action context=]
-    associated with the current execution context, return it.
-
-1.  Otherwise, create a new [=user action context=] identifier,
-    create a new [=user action context entry=] with:
-    *   [=user action context entry/Allowed Impression Sites=] set to an empty [=set=],
-    *   [=user action context entry/Impression Site Counter=] set to the [=impression site count cap=],
-    *   [=user action context entry/Allowed Conversion Sites=] set to an empty [=map=],
-    *   [=user action context entry/Conversion Site Counters=] set to an empty [=map=],
-
-    add the identifier and entry to the [=user action context store=],
-    and return the identifier.
-
-<p class=note>The [=user agent=] determines when [=user action contexts=] expire
-and are removed from the [=user action context store=].
-Contexts typically expire after some period of inactivity
-or when a new top-level navigation occurs.
-
-</div>
-
-<div algorithm>
-To <dfn>check impression site allowance</dfn>,
-given an [=impression site=] |impSite|
-and a [=user action context=] |uaContext|,
+To <dfn>check attribution API activation</dfn>,
+given a {{Window}} |window|,
 returning a [=boolean=]:
 
-1.  Let |entry| be the result of [=map/get|getting=] |uaContext|
-    from the [=user action context store=].
+1.  If |window|'s [=global attribution API flag=] is true, return true.
 
-1.  If |entry|'s [=user action context entry/Allowed Impression Sites=]
-    [=set/contains=] |impSite|, return true.
+1.  If |window| has [=transient activation=]:
 
-1.  If |entry|'s [=user action context entry/Impression Site Counter=] is 0,
-    return false.
+    1.  [=Consume user activation=] given |window|.
 
-1.  [=set/Append=] |impSite| to |entry|'s
-    [=user action context entry/Allowed Impression Sites=].
+    1.  Set |window|'s [=global attribution API flag=] to true.
 
-1.  Decrement |entry|'s [=user action context entry/Impression Site Counter=] by 1.
+    1.  Return true.
 
-1.  Return true.
-
-</div>
-
-<div algorithm>
-To <dfn>check conversion site allowance</dfn>,
-given a [=conversion site=] |convSite|,
-an [=epoch index=] |epoch|,
-and a [=user action context=] |uaContext|,
-returning a [=boolean=]:
-
-1.  Let |entry| be the result of [=map/get|getting=] |uaContext|
-    from the [=user action context store=].
-
-1.  If |entry|'s [=user action context entry/Conversion Site Counters=]
-    does not [=map/contain=] |epoch|:
-
-    1.  [=map/Set=] |entry|'s [=user action context entry/Conversion Site Counters=]\[|epoch|]
-        to the [=conversion site count cap=].
-
-    1.  [=map/Set=] |entry|'s [=user action context entry/Allowed Conversion Sites=]\[|epoch|]
-        to an empty [=set=].
-
-1.  Let |allowedSites| be the result of [=map/get|getting=] |epoch|
-    from |entry|'s [=user action context entry/Allowed Conversion Sites=].
-
-1.  If |allowedSites| [=set/contains=] |convSite|, return true.
-
-1.  Let |counter| be the result of [=map/get|getting=] |epoch|
-    from |entry|'s [=user action context entry/Conversion Site Counters=].
-
-1.  If |counter| is 0, return false.
-
-1.  [=set/Append=] |convSite| to |allowedSites|.
-
-1.  Decrement |entry|'s [=user action context entry/Conversion Site Counters=]\[|epoch|] by 1.
-
-1.  Return true.
+1.  Return false.
 
 </div>
 
@@ -1531,16 +1398,6 @@ returning an [=epoch index=]:
     The maximum privacy budget that a single [=impression site=]
     can enable to be consumed from the [=global privacy budget=] per [=epoch=],
     specified in [=microepsilons=].
-
-*   <dfn>Conversion site quota per epoch</dfn> (&epsilon;<sub>conv-quota</sub>):
-    The maximum privacy budget that a single [=conversion site=]
-    can consume from the [=global privacy budget=] per [=epoch=],
-    specified in [=microepsilons=].
-
-*   <dfn>Quota count cap</dfn> (<var>k</var><sub>quota-count</sub>):
-    The maximum number of distinct [=sites=]
-    that can create new quota budgets
-    within a single [=user action context=].
 
 <p class=note>Typical values might be:
 TODO
@@ -1666,8 +1523,7 @@ and a [=moment=] |now|:
     1.  [=map/clear|Clear=] the [=epoch start store=].
 
     <p class=issue>TODO: Define how to clear [=safety limits=] stores:
-    [=global privacy budget store=], [=impression site quota store=],
-    [=conversion site quota store=], and [=user action context store=].
+    [=global privacy budget store=] and [=impression site quota store=].
 
 1.  If |sites| [=set/is empty|is not empty=]:
 
@@ -1723,7 +1579,9 @@ and [=implicit API inputs=] |implicitInputs|:
         1.   otherwise, the result of
              [=obtain a site|obtaining a site=]
              from |settings|' [=environment settings object/origin=].
-    1.  Let |uaContext| be the [=current user action context=].
+1.  Let |window| be |document|'s [=relevant global object=].
+1.  Let |activationOk| be the result of [=check attribution API activation|checking attribution API activation=]
+    given |window|.
 1.  Validate the page-supplied API inputs:
     1.  If |options|.{{AttributionImpressionOptions/histogramIndex}} is
         greater than or equal to the [=implementation-defined=] [=maximum histogram size=],
@@ -1772,10 +1630,8 @@ and [=implicit API inputs=] |implicitInputs|:
          ::  |options|.{{AttributionImpressionOptions/histogramIndex}}
          :   [=impression/Priority=]
          ::  |options|.{{AttributionImpressionOptions/priority}}
-     1.  If the Attribution API is [[#opt-out|enabled]]:
-         1.  Let |allowed| be the result of [=check impression site allowance|checking impression site allowance=]
-             given |site| and |uaContext|.
-         1.  If |allowed| is true, save |impression| to the [=impression store=].
+     1.  If the Attribution API is [[#opt-out|enabled]] and |activationOk| is true:
+         1.  Save |impression| to the [=impression store=].
 
 1.  Let |result| be a new {{AttributionImpressionResult}}.
 1.  Return [=a promise resolved with=] |result| in |realm|.
@@ -1864,10 +1720,9 @@ and [=implicit API inputs=] |implicitInputs|:
         1.   otherwise, the result of
              [=obtain a site|obtaining a site=]
              from |settings|' [=environment settings object/origin=].
-    1.  Let |uaContext| be the [=current user action context=].
-
-        <p class=note>The [=user agent=] determines when a new [=user action context=] begins,
-        typically corresponding to a top-level navigation or other substantial user interaction.
+1.  Let |window| be |document|'s [=relevant global object=].
+1.  Let |activationOk| be the result of [=check attribution API activation|checking attribution API activation=]
+    given |window|.
 1.  Let |validatedOptions| be the result of
     [=validate AttributionConversionOptions|validating=] |options|,
     returning [=a promise rejected with=] any thrown reason.
@@ -1875,11 +1730,13 @@ and [=implicit API inputs=] |implicitInputs|:
 1.  Run the following steps [=in parallel=]:
      1.  Let |report| be the result of invoking [=create an all-zero histogram=] with
          |validatedOptions|' [=validated conversion options/histogram size=].
-     1.  If the Attribution API is [[#opt-out|enabled]], set |report| to the
-         result of [=do attribution and fill a histogram=] with |validatedOptions|,
+     1.  If the Attribution API is [[#opt-out|enabled]] and |activationOk| is true,
+         set |report| to the result of [=do attribution and fill a histogram=] with
+         |validatedOptions|,
          |implicitInputs|' [=implicit API inputs/top-level site=],
-         |implicitInputs|' [=implicit API inputs/intermediary site=], and
-         |implicitInputs|' [=implicit API inputs/timestamp=].
+         |implicitInputs|' [=implicit API inputs/intermediary site=],
+         |implicitInputs|' [=implicit API inputs/timestamp=], and
+         |activationOk|.
      1.  Let |aggregationService| be |validatedOptions|'s [=validated conversion options/aggregation service=].
      1.  Switch on the value of |aggregationService|.{{AttributionAggregationService/protocol}}:
          <dl class="switch">
@@ -2009,8 +1866,8 @@ To <dfn>do attribution and fill a histogram</dfn>, given
   [=validated conversion options=] |options|,
   [=site=] |topLevelSite|,
   [=site=] or `undefined` |intermediarySite|,
-  [=user action context=] |uaContext|,
-  and [=moment=] |now|:
+  [=moment=] |now|, and
+  [=boolean=] |activationOk|:
 
 1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
 
@@ -2037,9 +1894,6 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
         1.  If |impressions| [=set/is empty|is not empty=]:
 
-            1.  Let |quotaCountOk| be the result of invoking [=check conversion site allowance=]
-                with |topLevelSite|, |epoch|, and |uaContext|.
-
             1.  Let |impressionsByImpSite| be a new [=map=].
 
             1.  [=set/iterate|For each=] |impression| in |impressions|:
@@ -2060,7 +1914,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
                 |options|'s [=validated conversion options/max value=],
                 and null.
 
-            1.  If |quotaCountOk| is true and |budgetAndSafetyOk| is true,
+            1.  If |activationOk| is true and |budgetAndSafetyOk| is true,
                 [=set/extend=] |matchedImpressions| with |impressions|.
 
 

--- a/api.bs
+++ b/api.bs
@@ -1734,17 +1734,6 @@ and [=implicit API inputs=] |implicitInputs|:
 1.  If |document| is not [=allowed to use=] the [=policy-controlled feature=] named
     "{{PermissionPolicy/measure-conversion}}", return [=a promise rejected with=]
     a {{"NotAllowedError"}} {{DOMException}} in |realm|.
-1.  Let |settings| be [=this=]'s [=relevant settings object=].
-1.  Collect the implicit API inputs from |settings|:
-    1.  Let |now| be |settings|' [=environment settings object/current wall time=].
-    1.  Let |topLevelSite| (the [=conversion site=]) be the result of
-        [=obtain a site|obtaining a site=] from the [=top-level origin=].
-    1.  Let |intermediarySite| be:
-        1.   a value of `undefined` if the [=origin=] is [=same site=]
-             with the [=top-level origin=],
-        1.   otherwise, the result of
-             [=obtain a site|obtaining a site=]
-             from |settings|' [=environment settings object/origin=].
 1.  Let |window| be |document|'s [=relevant global object=].
 1.  Let |activationOk| be the result of [=check attribution API activation|checking attribution API activation=]
     given |window|.
@@ -1979,7 +1968,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
         |options|'s [=validated conversion options/max value=],
         and |l1Norm|.
 
-    1.  If |budgetAndSafetyOk| is false, set |histogram| to the result of invoking
+    1.  If |budgetAndSafetyOk| is false or |activationOk| is false, set |histogram| to the result of invoking
         [=create an all-zero histogram=] with |options|' [=validated conversion options/histogram size=].
 
 1.  Return |histogram|.

--- a/api.bs
+++ b/api.bs
@@ -2160,7 +2160,7 @@ it is not [=implementation-defined=].
 <p class=issue> Deciding on a value for differential privacy parameters
 is hard and therefore TBD.
 
-<dfn>Privacy Parameters</dfn>: [=User agents=] configure the [=privacy budget=] and [=safety limits=] by defining values
+[=User agents=] configure the [=privacy budget=] and [=safety limits=] by defining values
 for the following:
 
 *   The <dfn>per-site privacy budget</dfn> (&epsilon;<sub>site</sub>) within the range of: TBD

--- a/api.bs
+++ b/api.bs
@@ -1103,6 +1103,11 @@ These stores have some additional constraints
 on how information is cleared;
 see [[#clear-budget-store]] for details.
 
+<p class=issue>
+Some references to clearing
+the [=impression store=] may need to be
+updated to refer to the [=privacy budget store=] as well.
+
 
 ### Privacy Budget Store ### {#s-privacy-budget-store}
 
@@ -1179,111 +1184,7 @@ is added to the aggregated histogram.
 
 </div>
 
-<div algorithm>
-To <dfn>check and deduct safety limit budgets for impression sites</dfn>,
-given [=epoch index=] |epoch|,
-[=set=] of [=impression sites=] |impressionSites|,
-[=conversion site=] |conversionSite|,
-[=user action context=] |uaContext|,
-[[WEBIDL#idl-double|double]] |epsilon|,
-integer |value|,
-integer |maxValue|,
-and nullable integer |l1Norm|:
 
-1.  Let |sensitivity| be |l1Norm| if |l1Norm| is non-null, 2 * |value| otherwise.
-
-1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
-
-1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
-
-1.  If |deductionFp| is negative or greater than [=maximum epsilon=],
-    return false.
-
-1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
-
-1.  Let |accessedSites| be the [=map/get|value=] of |uaContext|
-    in the [=user action context store=],
-    or an empty [=set=] if not present.
-
-1.  Let |newSiteCount| be 0.
-
-1.  [=set/iterate|For each=] |impressionSite| in |impressionSites|:
-
-    1.  If |accessedSites| does not [=set/contain=] |impressionSite|,
-        increment |newSiteCount| by 1.
-
-1.  If |accessedSites| does not [=set/contain=] |conversionSite|,
-    increment |newSiteCount| by 1.
-
-1.  If ([=set/size=] of |accessedSites|) + |newSiteCount|
-    is greater than the [=quota count cap=], return false.
-
-    <p class=note>This check enforces the quota-count cap (<var>k</var><sub>quota-count</sub>)
-    from the Big Bird algorithm, which limits how many distinct sites
-    can create new quota budgets within a single user action.
-
-1.  Let |globalBudget| be the [=map/get|value=] of |epoch|
-    in the [=global privacy budget store=],
-    or the [=global budget per epoch=] if not present.
-
-1.  If |deduction| is greater than |globalBudget|, return false.
-
-1.  [=set/iterate|For each=] |impressionSite| in |impressionSites|:
-
-    1.  Let |impressionKey| be an [=impression site quota key=]
-        with |epoch| and |impressionSite|.
-
-    1.  Let |impressionQuota| be the [=map/get|value=] of |impressionKey|
-        in the [=impression site quota store=],
-        or the [=impression site quota per epoch=] if not present.
-
-    1.  If |deduction| is greater than |impressionQuota|, return false.
-
-1.  Let |conversionKey| be a [=conversion site quota key=]
-    with |epoch| and |conversionSite|.
-
-1.  Let |conversionQuota| be the [=map/get|value=] of |conversionKey|
-    in the [=conversion site quota store=],
-    or the [=conversion site quota per epoch=] if not present.
-
-1.  If |deduction| is greater than |conversionQuota|, return false.
-
-    <p class=note>The above steps implement the "Check" phase of the atomic two-phase commit protocol
-    from the Big Bird algorithm. All budget checks (quota-count, global budget, impression-site quotas,
-    and conversion-site quota) must succeed before any deductions are made.
-    If any check fails, the transaction aborts and NO budgets are deducted.
-
-1.  [=map/Set=] the [=global privacy budget store=]\[|epoch|]
-    to |globalBudget| − |deduction|.
-
-1.  [=set/iterate|For each=] |impressionSite| in |impressionSites|:
-
-    1.  Let |impressionKey| be an [=impression site quota key=]
-        with |epoch| and |impressionSite|.
-
-    1.  Let |impressionQuota| be the [=map/get|value=] of |impressionKey|
-        in the [=impression site quota store=],
-        or the [=impression site quota per epoch=] if not present.
-
-    1.  [=map/Set=] the [=impression site quota store=]\[|impressionKey|]
-        to |impressionQuota| − |deduction|.
-
-1.  [=map/Set=] the [=conversion site quota store=]\[|conversionKey|]
-    to |conversionQuota| − |deduction|.
-
-    <p class=note>The above steps implement the "Consume" phase of the atomic transaction.
-    Since all checks passed, we now commit by deducting from all relevant budgets.
-
-1.  [=set/iterate|For each=] |impressionSite| in |impressionSites|:
-
-    1.  [=set/Append=] |impressionSite| to |accessedSites|.
-
-1.  [=set/Append=] |conversionSite| to |accessedSites|.
-
-1.  [=map/Set=] the [=user action context store=]\[|uaContext|]
-    to |accessedSites|.
-
-1.  Return true.
 
 </div>
 
@@ -1476,7 +1377,7 @@ returning an [=epoch index=]:
 
 *   <dfn>Impression site quota per epoch</dfn> (&epsilon;<sub>imp-quota</sub>):
     The maximum privacy budget that a single [=impression site=]
-    can contribute to the [=global privacy budget=] per [=epoch=],
+    can enable to be consumed from the [=global privacy budget=] per [=epoch=],
     specified in [=microepsilons=].
 
 *   <dfn>Conversion site quota per epoch</dfn> (&epsilon;<sub>conv-quota</sub>):
@@ -1490,12 +1391,7 @@ returning an [=epoch index=]:
     within a single [=user action context=].
 
 <p class=note>Typical values might be:
-&epsilon;<sub>global</sub> = 10 &times; &epsilon;<sub>conv-quota</sub>,
-&epsilon;<sub>conv-quota</sub> = 1.5 &times; &epsilon;<sub>querier</sub>,
-&epsilon;<sub>imp-quota</sub> = <var>n</var> &times; 1.5 &times; &epsilon;<sub>querier</sub>,
-where &epsilon;<sub>querier</sub> is a typical per-site budget (e.g., 1.0)
-and <var>n</var> is the expected number of [=conversion sites=]
-that query a single [=impression site=] (e.g., 3-5).
+TODO
 
 
 ### Last Browsing History Clear Time ### {#last-clear}
@@ -1692,26 +1588,6 @@ The <dfn method for=Attribution>saveImpression(|options|)</dfn> method steps are
     1.  If any result in |conversionCallers| is failure, return
         [=a promise rejected with=] a {{"SyntaxError"}} {{DOMException}} in |realm|.
 1.  Run the following steps [=in parallel=]:
-     1.  Let |uaContext| be the [=current user action context=].
-
-     1.  Let |accessedSites| be the [=map/get|value=] of |uaContext|
-         in the [=user action context store=],
-         or an empty [=set=] if not present.
-
-     1.  If |accessedSites| does not [=set/contain=] |site|:
-
-         1.  If the [=set/size=] of |accessedSites| is greater than or equal to
-             the [=quota count cap=], return.
-
-             <p class=note>This implements the quota-count cap check from the Big Bird algorithm,
-             preventing a single user action from creating new impression-site quotas
-             for more than [=quota count cap=] distinct sites.
-
-         1.  [=set/Append=] |site| to |accessedSites|.
-
-         1.  [=map/Set=] the [=user action context store=]\[|uaContext|]
-             to |accessedSites|.
-
      1.  Construct |impression| as a [=impression|saved impression=] comprising:
          :   [=impression/Match Value=]
          ::  |options|.{{AttributionImpressionOptions/matchValue}}
@@ -1734,9 +1610,6 @@ The <dfn method for=Attribution>saveImpression(|options|)</dfn> method steps are
      1.  If the Attribution API is [[#opt-out|enabled]],
          save |impression| to the [=impression store=].
 
-         <p class=note>Impressions are stored with their timestamp,
-         which is later used to determine which [=epoch=] they belong to
-         when matching during conversion measurement.
 1.  Let |result| be a new {{AttributionImpressionResult}}.
 1.  Return [=a promise resolved with=] |result| in |realm|.
 
@@ -1929,33 +1802,15 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 1.  If |singleEpoch| is true:
     1.  Set |matchedImpressions| to the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |currentEpoch|, and |now|.
+    1. TODO safety limits in single-epoch case.
 
 1.  If |singleEpoch| is false:
-
-    <p class=note>When attributing across multiple [=epochs=],
-    each [=epoch=]'s [=impressions=] are evaluated separately.
-    [=Impressions=] are organized by [=epoch=] based on their [=impression/timestamp=]
-    relative to the [=conversion site=].
-    For each [=epoch=], both the per-[=site=] [=privacy budget=] and [=safety limits=]
-    are checked and deducted independently using an atomic transaction.
-    This approach ensures that budget consumption is properly tracked across time periods.
-
     1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
 
         1.  Let |impressions| be the result of invoking [=common matching logic=]
             with |options|, |topLevelSite|, |intermediarySite|, |epoch|, and |now|.
 
-            <p class=note>The [=common matching logic=] filters [=impressions=]
-            from the [=impression store=] by comparing each impression's [=impression/timestamp=]
-            against |topLevelSite| to determine which [=epoch=] it belongs to.
-            Only [=impressions=] that fall within the current |epoch| are selected.
-
         1.  If |impressions| [=set/is empty|is not empty=]:
-
-            1.  Let |impressionSites| be an [=set/is empty|empty=] [=set=].
-
-            1.  [=set/iterate|For each=] |impression| in |impressions|,
-                [=set/append=] |impression|'s [=impression/impression site=] to |impressionSites|.
 
             1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
@@ -1977,24 +1832,12 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
             1.  If |budgetOk| is true and |safetyOk| is true, [=set/extend=] |matchedImpressions| with |impressions|.
 
-                <p class=note>If either the per-[=site=] [=privacy budget=] or the [=safety limits=]
-                for a given [=epoch=] are insufficient, [=impressions=] from that [=epoch=] are excluded
-                from attribution (by dropping that epoch's data), but [=impressions=] from other [=epochs=]
-                with sufficient budget may still be included.
-                This implements the per-epoch atomic transaction pattern from the Big Bird algorithm.
+
 
 1.  If |matchedImpressions| [=set/is empty=], return the result of invoking
     [=create an all-zero histogram=] with
     |options|' [=validated conversion options/histogram size=].
 
-1.  Let |impressionSites| be an [=set/is empty|empty=] [=set=].
-
-1.  [=set/iterate|For each=] |impression| in |matchedImpressions|,
-    [=set/append=] |impression|'s [=impression/impression site=] to |impressionSites|.
-
-    <p class=note>The [=common matching logic=] can select [=impressions=]
-    from multiple [=impression sites=],
-    such as to support cross-publisher attribution.
 
 1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
     |options|' [=validated conversion options/histogram size=],

--- a/api.bs
+++ b/api.bs
@@ -1133,7 +1133,7 @@ A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items
 </dl>
 
 <div algorithm>
-To <dfn>deduct privacy budget</dfn>
+To <dfn>deduct privacy and safety budgets</dfn>
 given a [=privacy budget key=] |key|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
@@ -1905,25 +1905,19 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
         1.  If |impressions| [=set/is empty|is not empty=]:
 
+            1.  Let |quotaCountOk| be the result of invoking [=check conversion site allowance=]
+                with |topLevelSite|, |epoch|, and |uaContext|.
+
             1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
-            1.  Let |budgetOk| be the result of invoking [=deduct privacy budget=]
+            1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
                 with |key|, |options|' [=validated conversion options/epsilon=],
                 |options|' [=validated conversion options/value=],
                 |options|'s [=validated conversion options/max value=],
                 and null.
 
-            1.  Let |safetyOk| be the result of invoking [=check and deduct safety limit budgets for impression sites=]
-                with |epoch|,
-                |impressionSites|,
-                |topLevelSite|,
-                |uaContext|,
-                |options|' [=validated conversion options/epsilon=],
-                |options|' [=validated conversion options/value=],
-                |options|'s [=validated conversion options/max value=],
-                and null.
-
-            1.  If |budgetOk| is true and |safetyOk| is true, [=set/extend=] |matchedImpressions| with |impressions|.
+            1.  If |quotaCountOk| is true and |budgetAndSafetyOk| is true,
+                [=set/extend=] |matchedImpressions| with |impressions|.
 
 
 
@@ -1944,23 +1938,13 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
     1.  Let |key| be a [=privacy budget key=] whose items are |currentEpoch| and |topLevelSite|.
 
-    1.  Let |budgetOk| be the result of [=deduct privacy budget=]
+    1.  Let |budgetAndSafetyOk| be the result of [=deduct privacy and safety budgets=]
         with |key|, |options|' [=validated conversion options/epsilon=],
         |options|' [=validated conversion options/value=]
         |options|'s [=validated conversion options/max value=],
         and |l1Norm|.
 
-    1.  Let |safetyOk| be the result of invoking [=check and deduct safety limit budgets for impression sites=]
-        with |currentEpoch|,
-        |impressionSites|,
-        |topLevelSite|,
-        |uaContext|,
-        |options|' [=validated conversion options/epsilon=],
-        |options|' [=validated conversion options/value=],
-        |options|'s [=validated conversion options/max value=],
-        and |l1Norm|.
-
-    1.  If |budgetOk| is false or |safetyOk| is false, set |histogram| to the result of invoking
+    1.  If |budgetAndSafetyOk| is false, set |histogram| to the result of invoking
         [=create an all-zero histogram=] with |options|' [=validated conversion options/histogram size=].
 
 1.  Return |histogram|.

--- a/api.bs
+++ b/api.bs
@@ -1141,8 +1141,7 @@ A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items
 <div algorithm>
 To <dfn>deduct privacy and safety budgets</dfn>
 given a [=privacy budget key=] |key|,
-[=epoch index=] |epoch|,
-|impressions| as a set of [=impressions=],
+[=set=] of [=impressions=] |impressions|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|, and
@@ -1183,8 +1182,10 @@ nullable integer |l1Norm|:
 
     1.  [=set/Append=] |impression| to |impressionsBySite|\[|impressionSite|].
 
+1. Let |isSingleEpoch| be true if |l1Norm| is non-null, false otherwise.
+
 1.  Let |impressionSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
-    with |impressionsBySite|, |deduction|, |value|, |maxValue|, |epsilon|, and |l1Norm|.
+    with |impressionsBySite|, |deduction|, |value|, |maxValue|, |epsilon|, and |isSingleEpoch|.
 
 <p class=issue>TODO: Additional work to specify
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
@@ -1218,7 +1219,6 @@ how locking is performed to ensure atomicity across checks and deductions, but l
 <div algorithm>
 To <dfn>check for available privacy budget</dfn>
 given a [=privacy budget key=] |key|,
-[=epoch index=] |epoch|,
 integer |deduction|, and
 a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
 
@@ -1265,17 +1265,23 @@ integer |deduction|,
 integer |value|,
 integer |maxValue|,
 [[WEBIDL#idl-double|double]] |epsilon|, and
-nullable integer |l1Norm|:
+boolean |isSingleEpoch|:
 
 1.  Let |impressionSiteDeductions| be a new [=map=].
 
 1.  Let |numberImpressionSites| be the [=map/size|number of impression sites=] in |impressionsBySite|.
 
-1.  Let |singleEpoch| be true if |l1Norm| is non-null, false otherwise.
+1.  Let |sensitivity| be 2 * |value|.
+
+1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
+
+1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
+
+1.  Let |globalDeduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
 1.  [=map/iterate|For each=] |impressionSite| in |impressionsBySite|:
 
-    1.  If |singleEpoch| is true and |numberImpressionSites| is 1:
+    1.  If |isSingleEpoch| is true and |numberImpressionSites| is 1:
 
         1.  [=map/Set=] |impressionSiteDeductions|\[|impressionSite|] to |deduction|.
 
@@ -1286,15 +1292,7 @@ nullable integer |l1Norm|:
         <p class=note>In this case we need to use the global sensitivity which is the value of |deduction| only in the multi-epoch case;
         so we need to recompute it in case we are in the single epoch but multiple impression sites case.
 
-        1.  Let |sensitivity| be 2 * |value|.
-
-        1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
-
-        1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
-
-        1.  Let |siteDeduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
-
-        1.  [=map/Set=] |impressionSiteDeductions|\[|impressionSite|] to |siteDeduction|.
+        1.  [=map/Set=] |impressionSiteDeductions|\[|impressionSite|] to |globalDeduction|.
 
 1.  Return |impressionSiteDeductions|.
 
@@ -1954,21 +1952,10 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
 
-    1.  Let |impressionsBySite| be a new [=map=].
-
-    1.  [=set/iterate|For each=] |impression| in |matchedImpressions|:
-
-        1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
-
-        1.  If |impressionsBySite| does not [=map/contain=] |impressionSite|,
-            [=map/set=] |impressionsBySite|\[|impressionSite|] to an empty [=set=].
-
-        1.  [=set/Append=] |impression| to |impressionsBySite|\[|impressionSite|].
-
     1.  Let |key| be a [=privacy budget key=] whose items are |currentEpoch| and |topLevelSite|.
 
-    1.  Let |budgetAndSafetyOk| be the result of [=deduct privacy and safety budgets=]
-        with |key|, |currentEpoch|, |impressionsBySite|,
+    1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
+        with |key|, |currentEpoch|, |impressions|,
         |options|' [=validated conversion options/epsilon=],
         |options|' [=validated conversion options/value=]
         |options|'s [=validated conversion options/max value=],

--- a/api.bs
+++ b/api.bs
@@ -1186,7 +1186,6 @@ is added to the aggregated histogram.
 
 
 
-</div>
 
 ### Global Privacy Budget Store ### {#s-global-privacy-budget-store}
 
@@ -1802,7 +1801,6 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 1.  If |singleEpoch| is true:
     1.  Set |matchedImpressions| to the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |currentEpoch|, and |now|.
-    1. TODO safety limits in single-epoch case.
 
 1.  If |singleEpoch| is false:
     1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:

--- a/api.bs
+++ b/api.bs
@@ -1150,9 +1150,6 @@ nullable integer |l1Norm|:
 
 1.  Let |conversionSite| be the [=site=] component of |key|.
 
-1.  If there are no impressions in the current epoch, no privacy loss is deducted from budgets or quotas.
-    1.  Return true.
-
 1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
     its value of |key| to be a [=user agent=]-defined value,
     plus 1000.
@@ -1236,19 +1233,27 @@ To <dfn>compute impression site deductions</dfn>
 given a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of [=impressions=],
 and integer |deduction|:
 
-<p class=note>This function currently includes only a basic optimization
-that assigns zero deduction to impression sites with no impressions.
-Additional optimizations are possible and may be added to this function in the future.
-
-1.  Let |impSiteDeductions| be a new [=map=].
+1. Let |impSiteDeductions| be a new [=map=].
+1. Let |numberImpressionSites| be the number of impression sites in |impressionsByImpSite|.
 
 1.  [=map/iterate|For each=] |impSite| → |impressions| in |impressionsByImpSite|:
 
     1.  If |impressions| [=set/is empty=]:
         1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to 0.
 
-    1.  Otherwise:
+    1.  else if |singleEpoch| is true and |numImpressionSites| is 1:
         1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |deduction|.
+    1. else
+        <p class=note> In this case we need to use the global sensitivity which is the value of |deduction| only in the multi-epoch case;
+        so we need to recompute it case we are in the single epoch but multiple impression sites case.
+        1.  Let |sensitivity| be 2 * |value| otherwise.
+
+        1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
+
+        1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
+        1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
+
+        1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |deduction|
 
 1.  Return |impSiteDeductions|.
 

--- a/api.bs
+++ b/api.bs
@@ -1254,7 +1254,7 @@ a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
     1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|
         and |siteDeduction| is greater than the [=impression site quota per epoch=], return false.
 
-    1.  If [=map/contains] |impressionQuotaKey| and |siteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
+    1.  If [=map/contains=] |impressionQuotaKey| and |siteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
         return false.
 
 1.  Return true.

--- a/api.bs
+++ b/api.bs
@@ -1362,9 +1362,9 @@ and under what conditions it should be reset (e.g., navigation, page lifecycle e
 <div algorithm>
 To <dfn>check attribution API activation</dfn>,
 given a {{Window}} |window|,
-returning a [=boolean=]:
+throwing a {{"NotAllowedError"}} {{DOMException}} on failure:
 
-1.  If |window|'s [=global attribution API flag=] is true, return true.
+1.  If |window|'s [=global attribution API flag=] is true, return.
 
 1.  If |window| has [=transient activation=]:
 
@@ -1372,9 +1372,9 @@ returning a [=boolean=]:
 
     1.  Set |window|'s [=global attribution API flag=] to true.
 
-    1.  Return true.
+    1.  Return.
 
-1.  Return false.
+1.  [=Throw=] a {{"NotAllowedError"}} {{DOMException}}.
 
 </div>
 
@@ -1620,8 +1620,8 @@ and [=implicit API inputs=] |implicitInputs|:
     "{{PermissionPolicy/save-impression}}", return [=a promise rejected with=]
     a {{"NotAllowedError"}} {{DOMException}} in |realm|.
 1.  Let |window| be |document|'s [=relevant global object=].
-1.  Let |activationOk| be the result of [=check attribution API activation|checking attribution API activation=]
-    given |window|.
+1.  [=check attribution API activation|Check attribution API activation=]
+    given |window|, returning [=a promise rejected with=] any thrown reason.
 1.  Validate the page-supplied API inputs:
     1.  If |options|.{{AttributionImpressionOptions/histogramIndex}} is
         greater than or equal to the [=implementation-defined=] [=maximum histogram size=],
@@ -1670,7 +1670,7 @@ and [=implicit API inputs=] |implicitInputs|:
          ::  |options|.{{AttributionImpressionOptions/histogramIndex}}
          :   [=impression/Priority=]
          ::  |options|.{{AttributionImpressionOptions/priority}}
-     1.  If the Attribution API is [[#opt-out|enabled]] and |activationOk| is true:
+     1.  If the Attribution API is [[#opt-out|enabled]]:
          1.  Save |impression| to the [=impression store=].
 
 1.  Let |result| be a new {{AttributionImpressionResult}}.
@@ -1750,8 +1750,8 @@ and [=implicit API inputs=] |implicitInputs|:
     "{{PermissionPolicy/measure-conversion}}", return [=a promise rejected with=]
     a {{"NotAllowedError"}} {{DOMException}} in |realm|.
 1.  Let |window| be |document|'s [=relevant global object=].
-1.  Let |activationOk| be the result of [=check attribution API activation|checking attribution API activation=]
-    given |window|.
+1.  [=check attribution API activation|Check attribution API activation=]
+    given |window|, returning [=a promise rejected with=] any thrown reason.
 1.  Let |validatedOptions| be the result of
     [=validate AttributionConversionOptions|validating=] |options|,
     returning [=a promise rejected with=] any thrown reason.
@@ -1759,13 +1759,12 @@ and [=implicit API inputs=] |implicitInputs|:
 1.  Run the following steps [=in parallel=]:
      1.  Let |report| be the result of invoking [=create an all-zero histogram=] with
          |validatedOptions|' [=validated conversion options/histogram size=].
-     1.  If the Attribution API is [[#opt-out|enabled]] and |activationOk| is true,
+     1.  If the Attribution API is [[#opt-out|enabled]],
          set |report| to the result of [=do attribution and fill a histogram=] with
          |validatedOptions|,
          |implicitInputs|' [=implicit API inputs/top-level site=],
-         |implicitInputs|' [=implicit API inputs/intermediary site=],
-         |implicitInputs|' [=implicit API inputs/timestamp=], and
-         |activationOk|.
+         |implicitInputs|' [=implicit API inputs/intermediary site=], and
+         |implicitInputs|' [=implicit API inputs/timestamp=].
      1.  Let |aggregationService| be |validatedOptions|'s [=validated conversion options/aggregation service=].
      1.  Switch on the value of |aggregationService|.{{AttributionAggregationService/protocol}}:
          <dl class="switch">
@@ -1894,9 +1893,8 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
 To <dfn>do attribution and fill a histogram</dfn>, given
   [=validated conversion options=] |options|,
   [=site=] |topLevelSite|,
-  [=site=] or `undefined` |intermediarySite|,
-  [=moment=] |now|, and
-  [=boolean=] |activationOk|:
+  [=site=] or `undefined` |intermediarySite|, and
+  [=moment=] |now|:
 
 1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
 
@@ -1932,7 +1930,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
                 |options|'s [=validated conversion options/max value=],
                 and null.
 
-            1.  If |activationOk| is true and |budgetAndSafetyOk| is true,
+            1.  If |budgetAndSafetyOk| is true,
                 [=set/extend=] |matchedImpressions| with |impressions|.
 
 
@@ -1961,7 +1959,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
         |options|'s [=validated conversion options/max value=],
         and |l1Norm|.
 
-    1.  If |budgetAndSafetyOk| is false or |activationOk| is false, set |histogram| to the result of invoking
+    1.  If |budgetAndSafetyOk| is false, set |histogram| to the result of invoking
         [=create an all-zero histogram=] with |options|' [=validated conversion options/histogram size=].
 
 1.  Return |histogram|.

--- a/api.bs
+++ b/api.bs
@@ -1185,7 +1185,7 @@ nullable integer |l1Norm|:
 1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
 1.  Let |impSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
-    with |impressionsByImpSite|, |deduction|, |value|, |l1Norm|
+    with |impressionsByImpSite|, |deduction|, |value|, |maxValue|, |epsilon|, and |l1Norm|.
 
 1.  Check that sufficient budget exists in all relevant stores
     before deducting from any of them.
@@ -1231,29 +1231,37 @@ nullable integer |l1Norm|:
 <div algorithm>
 To <dfn>compute impression site deductions</dfn>
 given a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of [=impressions=],
-and integer |deduction|:
+integer |deduction|,
+integer |value|,
+integer |maxValue|,
+[[WEBIDL#idl-double|double]] |epsilon|, and
+nullable integer |l1Norm|:
 
-1. Let |impSiteDeductions| be a new [=map=].
+1.  Let |impSiteDeductions| be a new [=map=].
 
-1. Let |numberImpressionSites| be the number of impression sites in |impressionsByImpSite|.
+1.  Let |numberImpressionSites| be the number of impression sites in |impressionsByImpSite|.
 
-1. Let |singleEpoch| be true if |l1Norm| is non-null, false otherwise.
+1.  Let |singleEpoch| be true if |l1Norm| is non-null, false otherwise.
 
 1.  [=map/iterate|For each=] |impSite| → |impressions| in |impressionsByImpSite|:
-    1.  If |singleEpoch| is true and |numImpressionSites| is 1:
+
+    1.  If |singleEpoch| is true and |numberImpressionSites| is 1:
         1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |deduction|.
-    1. else
-        <p class=note> In this case we need to use the global sensitivity which is the value of |deduction| only in the multi-epoch case;
-        so we need to recompute it case we are in the single epoch but multiple impression sites case.
-        1.  Let |sensitivity| be 2 * |value| otherwise.
+
+    1.  Otherwise:
+
+        <p class=note>In this case we need to use the global sensitivity which is the value of |deduction| only in the multi-epoch case;
+        so we need to recompute it in case we are in the single epoch but multiple impression sites case.
+
+        1.  Let |sensitivity| be 2 * |value|.
 
         1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
 
         1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
 
-        1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
+        1.  Let |siteDeduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
-        1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |deduction|
+        1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |siteDeduction|.
 
 1.  Return |impSiteDeductions|.
 

--- a/api.bs
+++ b/api.bs
@@ -3137,7 +3137,7 @@ for [=epochs=] from which the [=attribution logic=] selected [=impressions=].
     corresponding to impressions from Sites B, C, and E.
 
     As a result, [=privacy budget=] for the [=conversion site=]
-    is [=deduct privacy budget|deducted=]
+    is [=deduct privacy and safety budgets|deducted=]
     from [=epochs=] 1, 3, 4, and 5.
     No impressions were recorded for [=epoch=] 2,
     so no [=privacy budget|budget=] is deducted from that [=epoch=].

--- a/api.bs
+++ b/api.bs
@@ -1132,32 +1132,7 @@ A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items
 
 </dl>
 
-<div algorithm>
-To <dfn>compute impression site deductions</dfn>,
-given a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of [=impressions=],
-and an integer |totalDeduction|,
-returning a [=map=] from [=impression sites=] to integers:
 
-1.  Let |totalImpressions| be 0.
-
-1.  [=map/iterate|For each=] |impSite| → |impressions| in |impressionsByImpSite|:
-
-    1.  Increment |totalImpressions| by the [=set/size=] of |impressions|.
-
-1.  Let |impSiteDeductions| be a new [=map=].
-
-1.  [=map/iterate|For each=] |impSite| → |impressions| in |impressionsByImpSite|:
-
-    1.  Let |count| be the [=set/size=] of |impressions|.
-
-    1.  Let |siteDeduction| be (|count| / |totalImpressions|) * |totalDeduction|,
-        rounded towards positive Infinity.
-
-    1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |siteDeduction|.
-
-1.  Return |impSiteDeductions|.
-
-</div>
 
 <div algorithm>
 To <dfn>deduct privacy and safety budgets</dfn>

--- a/api.bs
+++ b/api.bs
@@ -1133,12 +1133,44 @@ A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items
 </dl>
 
 <div algorithm>
+To <dfn>compute impression site deductions</dfn>,
+given a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of [=impressions=],
+and an integer |totalDeduction|,
+returning a [=map=] from [=impression sites=] to integers:
+
+1.  Let |totalImpressions| be 0.
+
+1.  [=map/iterate|For each=] |impSite| → |impressions| in |impressionsByImpSite|:
+
+    1.  Increment |totalImpressions| by the [=set/size=] of |impressions|.
+
+1.  Let |impSiteDeductions| be a new [=map=].
+
+1.  [=map/iterate|For each=] |impSite| → |impressions| in |impressionsByImpSite|:
+
+    1.  Let |count| be the [=set/size=] of |impressions|.
+
+    1.  Let |siteDeduction| be (|count| / |totalImpressions|) * |totalDeduction|,
+        rounded towards positive Infinity.
+
+    1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |siteDeduction|.
+
+1.  Return |impSiteDeductions|.
+
+</div>
+
+<div algorithm>
 To <dfn>deduct privacy and safety budgets</dfn>
 given a [=privacy budget key=] |key|,
+a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of [=impressions=],
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|, and
 nullable integer |l1Norm|:
+
+1.  Let |epoch| be the [=epoch index=] component of |key|.
+
+1.  Let |conversionSite| be the [=site=] component of |key|.
 
 1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
     its value of |key| to be a [=user agent=]-defined value,
@@ -1174,13 +1206,60 @@ is added to the aggregated histogram.
 
 1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
-1.  If |deduction| is greater than |currentValue|,
-    [=map/set|set=] the value of |key| in the [=privacy budget store=] to 0
-    and return false.
+1.  Let |impSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
+    with |impressionsByImpSite|, |value|, |maxValue|, |epsilon|
 
-1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
-    to |currentValue| − |deduction|
-    and return true.
+    <p class=issue>TODO: The [=compute impression site deductions=] function needs to still be defined.
+
+1.  Check that sufficient budget exists in all relevant stores
+    before deducting from any of them.
+    This ensures atomicity: either all deductions succeed, or none occur.
+
+    1.  If |deduction| is greater than |currentValue|, return false.
+
+    1.  If the [=global privacy budget store=] does not [=map/contain=] |epoch|,
+        [=map/set=] its value to the [=global budget per epoch=].
+
+    1.  If |deduction| is greater than [=global privacy budget store=]\[|epoch|],
+        return false.
+
+    1.  Let |convQuotaKey| be a [=conversion site quota key=]
+        whose items are |epoch| and |conversionSite|.
+
+    1.  If the [=conversion site quota store=] does not [=map/contain=] |convQuotaKey|,
+        [=map/set=] its value to the [=conversion site quota per epoch=].
+
+    1.  If |deduction| is greater than [=conversion site quota store=]\[|convQuotaKey|],
+        return false.
+
+    1.  [=map/iterate|For each=] |impSite| → |siteDeduction| in |impSiteDeductions|:
+
+        1.  Let |impQuotaKey| be an [=impression site quota key=]
+            whose items are |epoch| and |impSite|.
+
+        1.  If the [=impression site quota store=] does not [=map/contain=] |impQuotaKey|,
+            [=map/set=] its value to the [=impression site quota per epoch=].
+
+        1.  If |siteDeduction| is greater than [=impression site quota store=]\[|impQuotaKey|],
+            return false.
+
+1.  All budget checks passed; perform the deductions atomically.
+
+    1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
+        to |currentValue| − |deduction|.
+
+    1.  Decrement [=global privacy budget store=]\[|epoch|] by |deduction|.
+
+    1.  Decrement [=conversion site quota store=]\[|convQuotaKey|] by |deduction|.
+
+    1.  [=map/iterate|For each=] |impSite| → |siteDeduction| in |impSiteDeductions|:
+
+        1.  Let |impQuotaKey| be an [=impression site quota key=]
+            whose items are |epoch| and |impSite|.
+
+        1.  Decrement [=impression site quota store=]\[|impQuotaKey|] by |siteDeduction|.
+
+1.  Return true.
 
 </div>
 
@@ -1908,10 +1987,22 @@ To <dfn>do attribution and fill a histogram</dfn>, given
             1.  Let |quotaCountOk| be the result of invoking [=check conversion site allowance=]
                 with |topLevelSite|, |epoch|, and |uaContext|.
 
+            1.  Let |impressionsByImpSite| be a new [=map=].
+
+            1.  [=set/iterate|For each=] |impression| in |impressions|:
+
+                1.  Let |impSite| be |impression|'s [=impression/impression site=].
+
+                1.  If |impressionsByImpSite| does not [=map/contain=] |impSite|,
+                    [=map/set=] |impressionsByImpSite|\[|impSite|] to an empty [=set=].
+
+                1.  [=set/Append=] |impression| to |impressionsByImpSite|\[|impSite|].
+
             1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
             1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-                with |key|, |options|' [=validated conversion options/epsilon=],
+                with |key|, |impressionsByImpSite|,
+                |options|' [=validated conversion options/epsilon=],
                 |options|' [=validated conversion options/value=],
                 |options|'s [=validated conversion options/max value=],
                 and null.
@@ -1936,10 +2027,22 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
 
+    1.  Let |impressionsByImpSite| be a new [=map=].
+
+    1.  [=set/iterate|For each=] |impression| in |matchedImpressions|:
+
+        1.  Let |impSite| be |impression|'s [=impression/impression site=].
+
+        1.  If |impressionsByImpSite| does not [=map/contain=] |impSite|,
+            [=map/set=] |impressionsByImpSite|\[|impSite|] to an empty [=set=].
+
+        1.  [=set/Append=] |impression| to |impressionsByImpSite|\[|impSite|].
+
     1.  Let |key| be a [=privacy budget key=] whose items are |currentEpoch| and |topLevelSite|.
 
     1.  Let |budgetAndSafetyOk| be the result of [=deduct privacy and safety budgets=]
-        with |key|, |options|' [=validated conversion options/epsilon=],
+        with |key|, |impressionsByImpSite|,
+        |options|' [=validated conversion options/epsilon=],
         |options|' [=validated conversion options/value=]
         |options|'s [=validated conversion options/max value=],
         and |l1Norm|.

--- a/api.bs
+++ b/api.bs
@@ -1412,23 +1412,6 @@ returning an [=epoch index=]:
 
 </div>
 
-### Safety Limits Configuration ### {#safety-limits-configuration}
-
-[=User agents=] configure [=safety limits=] by defining the following values:
-
-*   <dfn>Global budget per epoch</dfn> (&epsilon;<sub>global</sub>):
-    The maximum privacy budget available across all [=sites=] per [=epoch=],
-    specified in [=microepsilons=].
-
-*   <dfn>Impression site quota per epoch</dfn> (&epsilon;<sub>imp-quota</sub>):
-    The maximum privacy budget that a single [=impression site=]
-    can enable to be consumed from the [=global privacy budget=] per [=epoch=],
-    specified in [=microepsilons=].
-
-<p class=note>Typical values might be:
-TODO
-
-
 ### Last Browsing History Clear Time ### {#last-clear}
 
 The <dfn>last browsing history clear</dfn> is a [=moment=]
@@ -2177,6 +2160,29 @@ it is not [=implementation-defined=].
 
 Deciding on a value for differential privacy parameters
 is hard and therefore TBD.
+
+### Safety Limits Configuration ### {#safety-limits-configuration}
+
+[=User agents=] configure [=safety limits=] by defining values
+as multiples of the per-[=site=] [=privacy budget=] (&epsilon;<sub>site</sub>):
+
+*   <dfn>Global budget per epoch</dfn> (&epsilon;<sub>global</sub>):
+    The maximum privacy budget available across all [=sites=] per [=epoch=],
+    specified in [=microepsilons=].
+    Implementations [=must=] set this value to at least 100 times
+    the per-[=site=] [=privacy budget=] per [=epoch=].
+
+*   <dfn>Impression site quota per epoch</dfn> (&epsilon;<sub>imp-quota</sub>):
+    The maximum privacy budget that a single [=impression site=]
+    can enable to be consumed from the [=global privacy budget=] per [=epoch=],
+    specified in [=microepsilons=].
+    Implementations [=must=] set this value to at least 10 times
+    the per-[=site=] [=privacy budget=] per [=epoch=].
+
+<p class=note>Setting [=safety limits=] as multiples of the per-[=site=] budget
+ensures that exploiting shared limits requires coordination by many sites,
+making them primarily useful as a means of protecting against abuse
+rather than as a primary privacy mechanism.
 
 
 ## User Control and Visibility ## {#user-control}

--- a/api.bs
+++ b/api.bs
@@ -1142,26 +1142,13 @@ A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items
 To <dfn>deduct privacy and safety budgets</dfn>
 given a [=privacy budget key=] |key|,
 [=epoch index=] |epoch|,
-a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of [=impressions=],
+a [=map=] |impressionsBySite| from [=impression sites=] to [=sets=] of [=impressions=],
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|, and
 nullable integer |l1Norm|:
 
-
 1.  Let |epoch| be the [=epoch index=] component of |key|.
-
-1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
-    its value of |key| to be a [=user agent=]-defined value,
-    plus 1000.
-
-    <p class=note>The addition of 1000 to this value
-    ensures that the rounding errors added by this algorithm do not cause
-    the budget to be exceeded unnecessarily after multiple invocations.
-    The privacy loss from the additional one-thousandth of an epsilon is trivial.
-
-1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
-    in the [=privacy budget store=].
 
 1.  Let |sensitivity| be |l1Norm| if |l1Norm| is non-null, 2 * |value| otherwise.
 
@@ -1185,12 +1172,18 @@ nullable integer |l1Norm|:
 
 1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
-1.  Let |impSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
-    with |impressionsByImpSite|, |deduction|, |value|, |maxValue|, |epsilon|, and |l1Norm|.
+1.  Let |impressionSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
+    with |impressionsBySite|, |deduction|, |value|, |maxValue|, |epsilon|, and |l1Norm|.
 
 1.  Check that sufficient budget exists in all relevant stores
     before deducting from any of them.
     This ensures atomicity: either all deductions succeed, or none occur.
+
+    <p class=issue>TODO: This section needs additional work to specify
+    how locking is performed to ensure atomicity across multiple stores.
+
+    1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
+        in the [=privacy budget store=].
 
     1.  If |deduction| is greater than |currentValue|, return false.
 
@@ -1200,28 +1193,37 @@ nullable integer |l1Norm|:
     1.  If |deduction| is greater than [=global privacy budget store=]\[|epoch|],
         return false.
 
-    1.  [=map/iterate|For each=] |impSite| → |siteDeduction| in |impSiteDeductions|:
+    1.  [=map/iterate|For each=] |impressionSite| → |siteDeduction| in |impressionSiteDeductions|:
 
         1.  Let |impQuotaKey| be an [=impression site quota key=]
-            whose items are |epoch| and |impSite|.
+            whose items are |epoch| and |impressionSite|.
 
-        1.  If the [=impression site quota store=] does not [=map/contain=] |impQuotaKey|,
-            [=map/set=] its value to the [=impression site quota per epoch=].
+        1.  If the [=impression site quota store=] does not [=map/contain=] |impQuotaKey|, compare |siteDeduction| to the value of
+            [=impression site quota per epoch=] and if it is greater, return false.
 
         1.  If |siteDeduction| is greater than [=impression site quota store=]\[|impQuotaKey|],
             return false.
 
-1.  All budget checks passed; perform the deductions atomically.
+1.  All budget checks passed, so perform the deductions atomically:
+
+    1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
+        its value of |key| to be a [=user agent=]-defined value,
+        plus 1000.
+
+    <p class=note>The addition of 1000 to this value
+    ensures that the rounding errors added by this algorithm do not cause
+    the budget to be exceeded unnecessarily after multiple invocations.
+    The privacy loss from the additional one-thousandth of an epsilon is trivial.
 
     1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
         to |currentValue| − |deduction|.
 
     1.  Decrement [=global privacy budget store=]\[|epoch|] by |deduction|.
 
-    1.  [=map/iterate|For each=] |impSite| → |siteDeduction| in |impSiteDeductions|:
+    1.  [=map/iterate|For each=] |impressionSite| → |siteDeduction| in |impressionSiteDeductions|:
 
         1.  Let |impQuotaKey| be an [=impression site quota key=]
-            whose items are |epoch| and |impSite|.
+            whose items are |epoch| and |impressionSite|.
 
         1.  Decrement [=impression site quota store=]\[|impQuotaKey|] by |siteDeduction|.
 
@@ -1231,23 +1233,26 @@ nullable integer |l1Norm|:
 
 <div algorithm>
 To <dfn>compute impression site deductions</dfn>
-given a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of [=impressions=],
+given a [=map=] |impressionsBySite| from [=impression sites=] to [=sets=] of [=impressions=],
 integer |deduction|,
 integer |value|,
 integer |maxValue|,
 [[WEBIDL#idl-double|double]] |epsilon|, and
 nullable integer |l1Norm|:
 
-1.  Let |impSiteDeductions| be a new [=map=].
+1.  Let |impressionSiteDeductions| be a new [=map=].
 
-1.  Let |numberImpressionSites| be the number of impression sites in |impressionsByImpSite|.
+1.  Let |numberImpressionSites| be the [=map/size|number of impression sites=] in |impressionsBySite|.
 
 1.  Let |singleEpoch| be true if |l1Norm| is non-null, false otherwise.
 
-1.  [=map/iterate|For each=] |impSite| in |impressionsByImpSite|:
+1.  [=map/iterate|For each=] |impressionSite| in |impressionsBySite|:
 
     1.  If |singleEpoch| is true and |numberImpressionSites| is 1:
-        1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |deduction|.
+
+        1.  [=map/Set=] |impressionSiteDeductions|\[|impressionSite|] to |deduction|.
+
+        1.  Return |impressionSiteDeductions|.
 
     1.  Otherwise:
 
@@ -1262,9 +1267,9 @@ nullable integer |l1Norm|:
 
         1.  Let |siteDeduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
-        1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |siteDeduction|.
+        1.  [=map/Set=] |impressionSiteDeductions|\[|impressionSite|] to |siteDeduction|.
 
-1.  Return |impSiteDeductions|.
+1.  Return |impressionSiteDeductions|.
 
 </div>
 
@@ -1895,21 +1900,21 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
         1.  If |impressions| [=set/is empty|is not empty=]:
 
-            1.  Let |impressionsByImpSite| be a new [=map=].
+            1.  Let |impressionsBySite| be a new [=map=].
 
             1.  [=set/iterate|For each=] |impression| in |impressions|:
 
-                1.  Let |impSite| be |impression|'s [=impression/impression site=].
+                1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-                1.  If |impressionsByImpSite| does not [=map/contain=] |impSite|,
-                    [=map/set=] |impressionsByImpSite|\[|impSite|] to an empty [=set=].
+                1.  If |impressionsBySite| does not [=map/contain=] |impressionSite|,
+                    [=map/set=] |impressionsBySite|\[|impressionSite|] to an empty [=set=].
 
-                1.  [=set/Append=] |impression| to |impressionsByImpSite|\[|impSite|].
+                1.  [=set/Append=] |impression| to |impressionsBySite|\[|impressionSite|].
 
             1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
             1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-                with |key|, |epoch|, |impressionsByImpSite|,
+                with |key|, |epoch|, |impressionsBySite|,
                 |options|' [=validated conversion options/epsilon=],
                 |options|' [=validated conversion options/value=],
                 |options|'s [=validated conversion options/max value=],
@@ -1935,21 +1940,21 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
 
-    1.  Let |impressionsByImpSite| be a new [=map=].
+    1.  Let |impressionsBySite| be a new [=map=].
 
     1.  [=set/iterate|For each=] |impression| in |matchedImpressions|:
 
-        1.  Let |impSite| be |impression|'s [=impression/impression site=].
+        1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-        1.  If |impressionsByImpSite| does not [=map/contain=] |impSite|,
-            [=map/set=] |impressionsByImpSite|\[|impSite|] to an empty [=set=].
+        1.  If |impressionsBySite| does not [=map/contain=] |impressionSite|,
+            [=map/set=] |impressionsBySite|\[|impressionSite|] to an empty [=set=].
 
-        1.  [=set/Append=] |impression| to |impressionsByImpSite|\[|impSite|].
+        1.  [=set/Append=] |impression| to |impressionsBySite|\[|impressionSite|].
 
     1.  Let |key| be a [=privacy budget key=] whose items are |currentEpoch| and |topLevelSite|.
 
     1.  Let |budgetAndSafetyOk| be the result of [=deduct privacy and safety budgets=]
-        with |key|, |currentEpoch|, |impressionsByImpSite|,
+        with |key|, |currentEpoch|, |impressionsBySite|,
         |options|' [=validated conversion options/epsilon=],
         |options|' [=validated conversion options/value=]
         |options|'s [=validated conversion options/max value=],

--- a/api.bs
+++ b/api.bs
@@ -1151,8 +1151,6 @@ nullable integer |l1Norm|:
 
 1.  Let |epoch| be the [=epoch index=] component of |key|.
 
-1.  Let |conversionSite| be the [=site=] component of |key|.
-
 1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
     its value of |key| to be a [=user agent=]-defined value,
     plus 1000.
@@ -1246,7 +1244,7 @@ nullable integer |l1Norm|:
 
 1.  Let |singleEpoch| be true if |l1Norm| is non-null, false otherwise.
 
-1.  [=map/iterate|For each=] |impSite| → |impressions| in |impressionsByImpSite|:
+1.  [=map/iterate|For each=] |impSite| in |impressionsByImpSite|:
 
     1.  If |singleEpoch| is true and |numberImpressionSites| is 1:
         1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |deduction|.

--- a/api.bs
+++ b/api.bs
@@ -1138,15 +1138,20 @@ A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items
 <div algorithm>
 To <dfn>deduct privacy and safety budgets</dfn>
 given a [=privacy budget key=] |key|,
+[=epoch index=] |epoch|,
 a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of [=impressions=],
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|, and
 nullable integer |l1Norm|:
 
+
 1.  Let |epoch| be the [=epoch index=] component of |key|.
 
 1.  Let |conversionSite| be the [=site=] component of |key|.
+
+1.  If there are no impressions in the current epoch, no privacy loss is deducted from budgets or quotas.
+    1.  Return true.
 
 1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
     its value of |key| to be a [=user agent=]-defined value,
@@ -1183,9 +1188,7 @@ nullable integer |l1Norm|:
 1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
 1.  Let |impSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
-    with |impressionsByImpSite|, |value|, |maxValue|, |epsilon|
-
-    <p class=issue>TODO: The [=compute impression site deductions=] function needs to still be defined.
+    with |impressionsByImpSite| and |deduction|.
 
 1.  Check that sufficient budget exists in all relevant stores
     before deducting from any of them.
@@ -1225,6 +1228,29 @@ nullable integer |l1Norm|:
         1.  Decrement [=impression site quota store=]\[|impQuotaKey|] by |siteDeduction|.
 
 1.  Return true.
+
+</div>
+
+<div algorithm>
+To <dfn>compute impression site deductions</dfn>
+given a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of [=impressions=],
+and integer |deduction|:
+
+<p class=note>This function currently includes only a basic optimization
+that assigns zero deduction to impression sites with no impressions.
+Additional optimizations are possible and may be added to this function in the future.
+
+1.  Let |impSiteDeductions| be a new [=map=].
+
+1.  [=map/iterate|For each=] |impSite| → |impressions| in |impressionsByImpSite|:
+
+    1.  If |impressions| [=set/is empty=]:
+        1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to 0.
+
+    1.  Otherwise:
+        1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |deduction|.
+
+1.  Return |impSiteDeductions|.
 
 </div>
 
@@ -1908,7 +1934,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
             1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
             1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-                with |key|, |impressionsByImpSite|,
+                with |key|, |epoch|, |impressionsByImpSite|,
                 |options|' [=validated conversion options/epsilon=],
                 |options|' [=validated conversion options/value=],
                 |options|'s [=validated conversion options/max value=],
@@ -1948,7 +1974,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
     1.  Let |key| be a [=privacy budget key=] whose items are |currentEpoch| and |topLevelSite|.
 
     1.  Let |budgetAndSafetyOk| be the result of [=deduct privacy and safety budgets=]
-        with |key|, |impressionsByImpSite|,
+        with |key|, |currentEpoch|, |impressionsByImpSite|,
         |options|' [=validated conversion options/epsilon=],
         |options|' [=validated conversion options/value=]
         |options|'s [=validated conversion options/max value=],

--- a/api.bs
+++ b/api.bs
@@ -1145,7 +1145,8 @@ given a [=privacy budget key=] |key|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|,
-boolean |isSingleEpoch| and integer |l1Norm|:
+boolean |isSingleEpoch|, integer |l1Norm|, [=set=] of [=impression quota keys=] |deductedImpressionQuotas|
+and a [=set=] of [=safety limit epoch indicies=] |deductedGlobalBudgets|:
 
 1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
 
@@ -1170,9 +1171,9 @@ boolean |isSingleEpoch| and integer |l1Norm|:
 
 1.  Let |valueDeduction| be |valueDeductionFp| * 1000000, rounded towards positive Infinity.
 
-    <p class=note> One epoch (which is the epoch of the conversion site) may overlap with multiple global epochs used by the global budget
-    and cross-site quotas. We will look at each impression individually and map it to the global epoch it is in to deduct from the global budget
-    and impression site quota if those have not already deducted from in this epoch.
+    <p class=note> One [=epoch=] (which is the epoch of the conversion site) can overlap with multiple [=safety limit epochs=] used by the [=global budget=]
+    and [=impression site quotas=]. We will look at each impression individually and map it to the [=safety limit epoch=] it is in to deduct from the global budget
+    and impression site quota if those have not already deducted from in this call to [=measure a conversion=].
 
 <p class=issue>TODO: Additional work to specify
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
@@ -1195,21 +1196,17 @@ how locking is performed to ensure atomicity across checks and deductions, but l
     1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
         to |currentValue| − |deduction|.
 
-    1.  Let |deductedImpressionQuotas| be a new [=set=].
-
-    1.  Let |deductedGlobalEpochs| be a new [=set=].
-
     1.  [=list/iterate|For each=] |impression| in |impressions|:
 
         1.  Let |impressionTime| be |impression|'s [=impression/timestamp=].
 
         1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-        1.  Let |globalEpoch| be the result of [=get the current global epoch=]
+        1.  Let |safetyLimitEpoch| be the result of [=get the current safety limit epoch=]
             with |impressionTime|.
 
         1.  Let |impressionQuotaKey| be an [=impression site quota key=]
-            whose items are |globalEpoch| and |impressionSite|.
+            whose items are |safetyLimitEpoch| and |impressionSite|.
 
         1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
             [=map/set=] its value to the [=impression site quota per epoch=].
@@ -1218,9 +1215,9 @@ how locking is performed to ensure atomicity across checks and deductions, but l
             [=set/extend=] |deductedImpressionQuotas| with |impressionQuotaKey|
             and decrement [=impression site quota store=]\[|impressionQuotaKey|] by |valueDeduction|.
 
-        1.  If |deductedGlobalEpochs| does not [=map/contain=] |globalEpoch|,
-            [=set/extend=] |deductedGlobalEpochs| with |globalEpoch|
-            and decrement [=global privacy budget store=]\[|globalEpoch|] by |valueDeduction|.
+        1.  If |deductedGlobalBudgets| does not [=map/contain=] |safetyLimitEpoch|,
+            [=set/extend=] |deductedGlobalBudgets| with |safetyLimitEpoch|
+            and decrement [=global privacy budget store=]\[|safetyLimitEpoch|] by |valueDeduction|.
 
 1.  Return true.
 
@@ -1246,15 +1243,15 @@ integer |valueDeduction|,
 
     1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-    1.  Let |globalEpoch| be the result of [=get the current global epoch=]
+    1.  Let |safetyLimitEpoch| be the result of [=get the current safety limit epoch=]
         with |impressionTime|.
 
     1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
-        of |globalEpoch| from the [=global privacy budget store=], or the [=global privacy budget
+        of |safetyLimitEpoch| from the [=global privacy budget store=], or the [=global privacy budget
         per epoch=] if [=map/contain|no value has been set=].
 
     1.  Let |impressionQuotaKey| be an [=impression site quota key=]
-        whose items are |globalEpoch| and |impressionSite|.
+        whose items are |safetyLimitEpoch| and |impressionSite|.
 
     1.  Let |currentImpressionQuotaValue| be set to the value of [=map/get|getting the value=]
         of |impressionQuotaKey| from the [=impression site quota store=],
@@ -1305,14 +1302,6 @@ that any single [=impression site=] can contribute in an [=epoch=].
 This prevents a single [=impression site=]
 from enabling excessive budget
 that could be maliciously triggered.
-
-### Epoch Cadences ### {#s-epoch-cadences}
-Each site has a separate cadence for the epochs of its per-[=site=] [=privacy budget store=].
-A separate global epoch cadence is shared by the [=global privacy budget store=] and all of the
- [=impression site quota stores|impression site quota store=].  This is to ensure there is
- no device-specific value shared across sites that could potentially be learned through
- timing and side channel attacks.
-
 
 
 ### Attribution API Activation ### {#s-api-activation}
@@ -1444,6 +1433,37 @@ returning an [=epoch index=]:
 1.  Return |elapsed| as an integer, rounded towards negative Infinity.
 
 </div>
+
+### Saftety Limit Epoch Start ### {#s-epoch-start}
+A [=safety limit epoch=] starts at the same time for all devices.  This
+ensures that it does not create a device-specific value that could be learned
+through timing or other side-channel attacks.
+
+A <dfn>safety limit epoch</dfn> identifies a period of time. The length
+of a [=safety limit epoch=] is fixed at one [=day=]. The start time for an
+[=safetly limit epoch=] is defined relative to the [=Unix epoch=].
+
+An <dfn local-lt="safety limit epoch indices">safety limit epoch index</dfn> is an integer
+that refers to a given [=safety limit epoch=].
+An [=safety limit epoch index=] is used to access the
+[=global privacy budget store=] and the [=impression site quota stores=].
+
+[=moment|Points in time=] are translated to an [=safety limit epoch index=]
+for the corresponding [=safetly limit epoch=]
+using the [=get the current safetly limit epoch=] algorithm.
+
+<div algorithm>
+To <dfn>get the current safety limit epoch</dfn>
+given [=moment=] |t|,
+returning a [=safety limit epoch index=]:
+
+1.  Let |period| be the [=duration=] of one [=epoch=].
+
+1.  Let |start| be the [=Unix epoch=].
+
+1.  Let |elapsed| be (|t| − |start|) / |period|.
+
+1.  Return |elapsed| as an integer, rounded towards negative Infinity.
 
 ### Last Browsing History Clear Time ### {#last-clear}
 
@@ -1917,7 +1937,19 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
 
-1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
+1.  Let |deductedImpressionQuotas| be a new [=set=].
+
+1.  Let |deductedGlobalBudgets| be a new [=set=].
+
+<p class=note> The |deductedImpressionQuotas| and |deductedGlobalBudgets| sets are initialized outside the
+loop over epochs so that [=safety limit epochs=] which overlap two per-site [=epochs=] will not be have
+their safety limits deducted from more than once.
+
+1.  For each |epoch| from |currentEpoch| to |startEpoch|, inclusive:
+
+    <p class=note> Epochs are processed sequentially starting from the most recent epoch
+    and going back in time as safety limit deductions may depleate from same safety limits as
+    the next epoch will need to check.
 
     1.  Let |impressions| be the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |epoch|, and |now|.
@@ -1931,7 +1963,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
             |options|' [=validated conversion options/epsilon=],
             |options|' [=validated conversion options/value=],
             |options|'s [=validated conversion options/max value=],
-            |isSingleEpoch| and |l1Norm|.
+            |isSingleEpoch|, |l1Norm|, |deductedImpressionQuotas| and |deductedGlobalBudgets|.
 
         1.  If |budgetAndSafetyOk| is true,
             [=set/extend=] |matchedImpressions| with |impressions|.

--- a/api.bs
+++ b/api.bs
@@ -1068,13 +1068,12 @@ For example, "`extra.example.com`" is parsed as "`example.com`".
 
 ## State For Privacy Budget Management ## {#privacy-state}
 
-[=User agents=] maintain three pieces of state
+[=User agents=] maintain several pieces of state
 that are used to manage the expenditure of [=privacy budgets=]:
 
 *   The [=privacy budget store=] records the state
     of the per-[=site=] and per-[=epoch=] [=privacy budgets=].
     It is updated by [=deduct privacy budget=].
-
 
 *   The [=epoch start store=] records when each [=epoch=] starts
     for [=conversion sites=].
@@ -1084,18 +1083,25 @@ that are used to manage the expenditure of [=privacy budgets=]:
 *   A singleton [=last browsing history clear=] value
     that tracks when the browsing activity for a [=site=] was last cleared.
 
+*   The [=global privacy budget store=] records the state
+    of the per-[=epoch=] global [=privacy budget=]
+    that applies across all [=sites=].
+
+*   The [=impression site quota store=] records the state
+    of per-[=impression site=] and per-[=epoch=] quota [=privacy budgets=].
+
+*   The [=conversion site quota store=] records the state
+    of per-[=conversion site=] and per-[=epoch=] quota [=privacy budgets=].
+
+*   The [=user action context store=] records which [=sites=]
+    have accessed quota [=privacy budgets=] within the current [=user action context=].
+
 <p class=note>
 Like the [=impression store=],
-the [=privacy budget store=] does not use a [=storage key=].
+the [=privacy budget store=] and related stores do not use a [=storage key=].
 These stores have some additional constraints
 on how information is cleared;
 see [[#clear-budget-store]] for details.
-
-<p class=issue>
-The [=safety limits=] need to be described in more detail.
-Some references to clearing
-the [=impression store=] may need to be
-updated to refer to the [=privacy budget store=] as well.
 
 
 ### Privacy Budget Store ### {#s-privacy-budget-store}
@@ -1173,6 +1179,218 @@ is added to the aggregated histogram.
 
 </div>
 
+<div algorithm>
+To <dfn>check and deduct safety limit budgets for impression sites</dfn>,
+given [=epoch index=] |epoch|,
+[=set=] of [=impression sites=] |impressionSites|,
+[=conversion site=] |conversionSite|,
+[=user action context=] |uaContext|,
+[[WEBIDL#idl-double|double]] |epsilon|,
+integer |value|,
+integer |maxValue|,
+and nullable integer |l1Norm|:
+
+1.  Let |sensitivity| be |l1Norm| if |l1Norm| is non-null, 2 * |value| otherwise.
+
+1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
+
+1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
+
+1.  If |deductionFp| is negative or greater than [=maximum epsilon=],
+    return false.
+
+1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
+
+1.  Let |accessedSites| be the [=map/get|value=] of |uaContext|
+    in the [=user action context store=],
+    or an empty [=set=] if not present.
+
+1.  Let |newSiteCount| be 0.
+
+1.  [=set/iterate|For each=] |impressionSite| in |impressionSites|:
+
+    1.  If |accessedSites| does not [=set/contain=] |impressionSite|,
+        increment |newSiteCount| by 1.
+
+1.  If |accessedSites| does not [=set/contain=] |conversionSite|,
+    increment |newSiteCount| by 1.
+
+1.  If ([=set/size=] of |accessedSites|) + |newSiteCount|
+    is greater than the [=quota count cap=], return false.
+
+    <p class=note>This check enforces the quota-count cap (<var>k</var><sub>quota-count</sub>)
+    from the Big Bird algorithm, which limits how many distinct sites
+    can create new quota budgets within a single user action.
+
+1.  Let |globalBudget| be the [=map/get|value=] of |epoch|
+    in the [=global privacy budget store=],
+    or the [=global budget per epoch=] if not present.
+
+1.  If |deduction| is greater than |globalBudget|, return false.
+
+1.  [=set/iterate|For each=] |impressionSite| in |impressionSites|:
+
+    1.  Let |impressionKey| be an [=impression site quota key=]
+        with |epoch| and |impressionSite|.
+
+    1.  Let |impressionQuota| be the [=map/get|value=] of |impressionKey|
+        in the [=impression site quota store=],
+        or the [=impression site quota per epoch=] if not present.
+
+    1.  If |deduction| is greater than |impressionQuota|, return false.
+
+1.  Let |conversionKey| be a [=conversion site quota key=]
+    with |epoch| and |conversionSite|.
+
+1.  Let |conversionQuota| be the [=map/get|value=] of |conversionKey|
+    in the [=conversion site quota store=],
+    or the [=conversion site quota per epoch=] if not present.
+
+1.  If |deduction| is greater than |conversionQuota|, return false.
+
+    <p class=note>The above steps implement the "Check" phase of the atomic two-phase commit protocol
+    from the Big Bird algorithm. All budget checks (quota-count, global budget, impression-site quotas,
+    and conversion-site quota) must succeed before any deductions are made.
+    If any check fails, the transaction aborts and NO budgets are deducted.
+
+1.  [=map/Set=] the [=global privacy budget store=]\[|epoch|]
+    to |globalBudget| − |deduction|.
+
+1.  [=set/iterate|For each=] |impressionSite| in |impressionSites|:
+
+    1.  Let |impressionKey| be an [=impression site quota key=]
+        with |epoch| and |impressionSite|.
+
+    1.  Let |impressionQuota| be the [=map/get|value=] of |impressionKey|
+        in the [=impression site quota store=],
+        or the [=impression site quota per epoch=] if not present.
+
+    1.  [=map/Set=] the [=impression site quota store=]\[|impressionKey|]
+        to |impressionQuota| − |deduction|.
+
+1.  [=map/Set=] the [=conversion site quota store=]\[|conversionKey|]
+    to |conversionQuota| − |deduction|.
+
+    <p class=note>The above steps implement the "Consume" phase of the atomic transaction.
+    Since all checks passed, we now commit by deducting from all relevant budgets.
+
+1.  [=set/iterate|For each=] |impressionSite| in |impressionSites|:
+
+    1.  [=set/Append=] |impressionSite| to |accessedSites|.
+
+1.  [=set/Append=] |conversionSite| to |accessedSites|.
+
+1.  [=map/Set=] the [=user action context store=]\[|uaContext|]
+    to |accessedSites|.
+
+1.  Return true.
+
+</div>
+
+### Global Privacy Budget Store ### {#s-global-privacy-budget-store}
+
+The <dfn>global privacy budget store</dfn> is a [=map=] whose keys are
+[=epoch indices=] and whose values are [=32-bit unsigned integers=]
+in units of [=microepsilons=].
+
+The [=global privacy budget store=] enforces a single [=privacy budget=]
+per [=epoch=] that applies across all [=sites=].
+This provides a [=safety limit=] against adversaries
+that can correlate activity for the same person across multiple [=sites=].
+
+<p class=note>Unlike the per-[=site=] [=privacy budget store=],
+the [=global privacy budget store=] is keyed only by [=epoch index=],
+not by [=site=].
+
+
+### Impression Site Quota Store ### {#s-impression-site-quota-store}
+
+The <dfn>impression site quota store</dfn> is a [=map=] whose keys are
+[=impression site quota keys=] and whose values are [=32-bit unsigned integers=]
+in units of [=microepsilons=].
+
+An <dfn>impression site quota key</dfn> is a [=tuple=] consisting of the following items:
+
+<dl dfn-for="impression site quota key">
+: <dfn ignore>epoch index</dfn>
+:: An [=epoch index=]
+: <dfn ignore>impression site</dfn>
+:: An [=impression site=]
+
+</dl>
+
+The [=impression site quota store=] limits the amount of "stock"
+(privacy budget related to [=impressions=])
+that any single [=impression site=] can contribute in an [=epoch=].
+This prevents a single [=impression site=]
+from enabling excessive budget
+that could be maliciously triggered.
+
+
+### Conversion Site Quota Store ### {#s-conversion-site-quota-store}
+
+The <dfn>conversion site quota store</dfn> is a [=map=] whose keys are
+[=conversion site quota keys=] and whose values are [=32-bit unsigned integers=]
+in units of [=microepsilons=].
+
+A <dfn>conversion site quota key</dfn> is a [=tuple=] consisting of the following items:
+
+<dl dfn-for="conversion site quota key">
+: <dfn ignore>epoch index</dfn>
+:: An [=epoch index=]
+: <dfn ignore>conversion site</dfn>
+:: A [=conversion site=]
+
+</dl>
+
+The [=conversion site quota store=] limits the amount of "flow"
+(privacy budget consumed by reports)
+that any single [=conversion site=] can trigger in an [=epoch=].
+This constrains the budget that can be drawn by a [=conversion site=],
+limiting its ability to rapidly deplete the [=global privacy budget=].
+
+
+### User Action Context Store ### {#s-user-action-context-store}
+
+The <dfn>user action context store</dfn> is a [=map=] keyed by [=user action contexts=]
+and containing values that are [=sets=] of [=sites=].
+
+A <dfn>user action context</dfn> is an identifier
+for a sequence of API invocations
+that are associated with a single intentional user action,
+such as a navigation or click.
+
+The [=user action context store=] tracks which [=sites=]
+have accessed quota [=privacy budgets=]
+(either [=impression site quota store|impression site quotas=]
+or [=conversion site quota store|conversion site quotas=])
+within the current [=user action context=].
+This enables enforcement of the [=quota count cap=].
+
+<p class=note>A [=user action context=] typically corresponds to
+a top-level navigation or other substantial user interaction.
+[=User agents=] determine when a new [=user action context=] begins
+based on their understanding of intentional user actions.
+
+<div algorithm>
+To get the <dfn>current user action context</dfn>,
+returning a [=user action context=]:
+
+1.  If the [=user agent=] has an active [=user action context=]
+    associated with the current execution context, return it.
+
+1.  Otherwise, create a new [=user action context=] identifier,
+    add it to the [=user action context store=] with an empty [=set=] value,
+    and return it.
+
+<p class=note>The [=user agent=] determines when [=user action contexts=] expire
+and are removed from the [=user action context store=].
+Contexts typically expire after some period of inactivity
+or when a new top-level navigation occurs.
+
+</div>
+
+
 ### Epoch Start Store ### {#s-epoch-start}
 
 An [=epoch=] starts at a randomly-selected time
@@ -1247,6 +1465,38 @@ returning an [=epoch index=]:
 1.  Return |elapsed| as an integer, rounded towards negative Infinity.
 
 </div>
+
+### Safety Limits Configuration ### {#safety-limits-configuration}
+
+[=User agents=] configure [=safety limits=] by defining the following values:
+
+*   <dfn>Global budget per epoch</dfn> (&epsilon;<sub>global</sub>):
+    The maximum privacy budget available across all [=sites=] per [=epoch=],
+    specified in [=microepsilons=].
+
+*   <dfn>Impression site quota per epoch</dfn> (&epsilon;<sub>imp-quota</sub>):
+    The maximum privacy budget that a single [=impression site=]
+    can contribute to the [=global privacy budget=] per [=epoch=],
+    specified in [=microepsilons=].
+
+*   <dfn>Conversion site quota per epoch</dfn> (&epsilon;<sub>conv-quota</sub>):
+    The maximum privacy budget that a single [=conversion site=]
+    can consume from the [=global privacy budget=] per [=epoch=],
+    specified in [=microepsilons=].
+
+*   <dfn>Quota count cap</dfn> (<var>k</var><sub>quota-count</sub>):
+    The maximum number of distinct [=sites=]
+    that can create new quota budgets
+    within a single [=user action context=].
+
+<p class=note>Typical values might be:
+&epsilon;<sub>global</sub> = 10 &times; &epsilon;<sub>conv-quota</sub>,
+&epsilon;<sub>conv-quota</sub> = 1.5 &times; &epsilon;<sub>querier</sub>,
+&epsilon;<sub>imp-quota</sub> = <var>n</var> &times; 1.5 &times; &epsilon;<sub>querier</sub>,
+where &epsilon;<sub>querier</sub> is a typical per-site budget (e.g., 1.0)
+and <var>n</var> is the expected number of [=conversion sites=]
+that query a single [=impression site=] (e.g., 3-5).
+
 
 ### Last Browsing History Clear Time ### {#last-clear}
 
@@ -1367,6 +1617,10 @@ and a [=moment=] |now|:
 
     1.  [=map/clear|Clear=] the [=epoch start store=].
 
+    <p class=issue>TODO: Define how to clear [=safety limits=] stores:
+    [=global privacy budget store=], [=impression site quota store=],
+    [=conversion site quota store=], and [=user action context store=].
+
 1.  If |sites| [=set/is empty|is not empty=]:
 
     1.  [=set/iterate|For each=] |impression| in the [=impression store=],
@@ -1438,6 +1692,26 @@ The <dfn method for=Attribution>saveImpression(|options|)</dfn> method steps are
     1.  If any result in |conversionCallers| is failure, return
         [=a promise rejected with=] a {{"SyntaxError"}} {{DOMException}} in |realm|.
 1.  Run the following steps [=in parallel=]:
+     1.  Let |uaContext| be the [=current user action context=].
+
+     1.  Let |accessedSites| be the [=map/get|value=] of |uaContext|
+         in the [=user action context store=],
+         or an empty [=set=] if not present.
+
+     1.  If |accessedSites| does not [=set/contain=] |site|:
+
+         1.  If the [=set/size=] of |accessedSites| is greater than or equal to
+             the [=quota count cap=], return.
+
+             <p class=note>This implements the quota-count cap check from the Big Bird algorithm,
+             preventing a single user action from creating new impression-site quotas
+             for more than [=quota count cap=] distinct sites.
+
+         1.  [=set/Append=] |site| to |accessedSites|.
+
+         1.  [=map/Set=] the [=user action context store=]\[|uaContext|]
+             to |accessedSites|.
+
      1.  Construct |impression| as a [=impression|saved impression=] comprising:
          :   [=impression/Match Value=]
          ::  |options|.{{AttributionImpressionOptions/matchValue}}
@@ -1459,6 +1733,10 @@ The <dfn method for=Attribution>saveImpression(|options|)</dfn> method steps are
          ::  |options|.{{AttributionImpressionOptions/priority}}
      1.  If the Attribution API is [[#opt-out|enabled]],
          save |impression| to the [=impression store=].
+
+         <p class=note>Impressions are stored with their timestamp,
+         which is later used to determine which [=epoch=] they belong to
+         when matching during conversion measurement.
 1.  Let |result| be a new {{AttributionImpressionResult}}.
 1.  Return [=a promise resolved with=] |result| in |realm|.
 
@@ -1496,6 +1774,10 @@ The <dfn method for=Attribution>measureConversion(|options|)</dfn> method steps 
         1.   otherwise, the result of
              [=obtain a site|obtaining a site=]
              from |settings|' [=environment settings object/origin=].
+    1.  Let |uaContext| be the [=current user action context=].
+
+        <p class=note>The [=user agent=] determines when a new [=user action context=] begins,
+        typically corresponding to a top-level navigation or other substantial user interaction.
 1.  Let |validatedOptions| be the result of
     [=validate AttributionConversionOptions|validating=] |options|,
     returning [=a promise rejected with=] any thrown reason.
@@ -1505,7 +1787,7 @@ The <dfn method for=Attribution>measureConversion(|options|)</dfn> method steps 
          |validatedOptions|' [=validated conversion options/histogram size=].
      1.  If the Attribution API is [[#opt-out|enabled]], set |report| to the
          result of [=do attribution and fill a histogram=] with |validatedOptions|,
-         |topLevelSite|, |intermediarySite|, and |now|.
+         |topLevelSite|, |intermediarySite|, |uaContext|, and |now|.
      1.  Let |aggregationService| be |validatedOptions|'s [=validated conversion options/aggregation service=].
      1.  Switch on the value of |aggregationService|.{{AttributionAggregationService/protocol}}:
          <dl class="switch">
@@ -1628,6 +1910,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
   [=validated conversion options=] |options|,
   [=site=] |topLevelSite|,
   [=site=] or `undefined` |intermediarySite|,
+  [=user action context=] |uaContext|,
   and [=moment=] |now|:
 
 1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
@@ -1649,12 +1932,30 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
 1.  If |singleEpoch| is false:
 
+    <p class=note>When attributing across multiple [=epochs=],
+    each [=epoch=]'s [=impressions=] are evaluated separately.
+    [=Impressions=] are organized by [=epoch=] based on their [=impression/timestamp=]
+    relative to the [=conversion site=].
+    For each [=epoch=], both the per-[=site=] [=privacy budget=] and [=safety limits=]
+    are checked and deducted independently using an atomic transaction.
+    This approach ensures that budget consumption is properly tracked across time periods.
+
     1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
 
         1.  Let |impressions| be the result of invoking [=common matching logic=]
             with |options|, |topLevelSite|, |intermediarySite|, |epoch|, and |now|.
 
+            <p class=note>The [=common matching logic=] filters [=impressions=]
+            from the [=impression store=] by comparing each impression's [=impression/timestamp=]
+            against |topLevelSite| to determine which [=epoch=] it belongs to.
+            Only [=impressions=] that fall within the current |epoch| are selected.
+
         1.  If |impressions| [=set/is empty|is not empty=]:
+
+            1.  Let |impressionSites| be an [=set/is empty|empty=] [=set=].
+
+            1.  [=set/iterate|For each=] |impression| in |impressions|,
+                [=set/append=] |impression|'s [=impression/impression site=] to |impressionSites|.
 
             1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
@@ -1664,11 +1965,36 @@ To <dfn>do attribution and fill a histogram</dfn>, given
                 |options|'s [=validated conversion options/max value=],
                 and null.
 
-            1.  If |budgetOk| is true, [=set/extend=] |matchedImpressions| with |impressions|.
+            1.  Let |safetyOk| be the result of invoking [=check and deduct safety limit budgets for impression sites=]
+                with |epoch|,
+                |impressionSites|,
+                |topLevelSite|,
+                |uaContext|,
+                |options|' [=validated conversion options/epsilon=],
+                |options|' [=validated conversion options/value=],
+                |options|'s [=validated conversion options/max value=],
+                and null.
+
+            1.  If |budgetOk| is true and |safetyOk| is true, [=set/extend=] |matchedImpressions| with |impressions|.
+
+                <p class=note>If either the per-[=site=] [=privacy budget=] or the [=safety limits=]
+                for a given [=epoch=] are insufficient, [=impressions=] from that [=epoch=] are excluded
+                from attribution (by dropping that epoch's data), but [=impressions=] from other [=epochs=]
+                with sufficient budget may still be included.
+                This implements the per-epoch atomic transaction pattern from the Big Bird algorithm.
 
 1.  If |matchedImpressions| [=set/is empty=], return the result of invoking
     [=create an all-zero histogram=] with
     |options|' [=validated conversion options/histogram size=].
+
+1.  Let |impressionSites| be an [=set/is empty|empty=] [=set=].
+
+1.  [=set/iterate|For each=] |impression| in |matchedImpressions|,
+    [=set/append=] |impression|'s [=impression/impression site=] to |impressionSites|.
+
+    <p class=note>The [=common matching logic=] can select [=impressions=]
+    from multiple [=impression sites=],
+    such as to support cross-publisher attribution.
 
 1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
     |options|' [=validated conversion options/histogram size=],
@@ -1688,7 +2014,17 @@ To <dfn>do attribution and fill a histogram</dfn>, given
         |options|'s [=validated conversion options/max value=],
         and |l1Norm|.
 
-    1.  If |budgetOk| is false, set |histogram| to the result of invoking
+    1.  Let |safetyOk| be the result of invoking [=check and deduct safety limit budgets for impression sites=]
+        with |currentEpoch|,
+        |impressionSites|,
+        |topLevelSite|,
+        |uaContext|,
+        |options|' [=validated conversion options/epsilon=],
+        |options|' [=validated conversion options/value=],
+        |options|'s [=validated conversion options/max value=],
+        and |l1Norm|.
+
+    1.  If |budgetOk| is false or |safetyOk| is false, set |histogram| to the result of invoking
         [=create an all-zero histogram=] with |options|' [=validated conversion options/histogram size=].
 
 1.  Return |histogram|.

--- a/api.bs
+++ b/api.bs
@@ -1172,6 +1172,17 @@ nullable integer |l1Norm|:
 
 1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
+1.  Let |impressionsBySite| be a new [=map=].
+
+1.  [=set/iterate|For each=] |impression| in |impressions|:
+
+    1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
+
+    1.  If |impressionsBySite| does not [=map/contain=] |impressionSite|,
+        [=map/set=] |impressionsBySite|\[|impressionSite|] to an empty [=set=].
+
+    1.  [=set/Append=] |impression| to |impressionsBySite|\[|impressionSite|].
+
 1.  Let |impressionSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
     with |impressionsBySite|, |deduction|, |value|, |maxValue|, |epsilon|, and |l1Norm|.
 
@@ -1336,14 +1347,12 @@ that could be maliciously triggered.
 
 The Attribution API requires user activation to prevent abuse.
 A <dfn>global attribution API flag</dfn> is associated with each {{Window}} object.
+The [=global attribution API flag=] is enabled whenever the API is successfully invoked.
 This flag is initially false.
 
 The API can be invoked if either:
 1.  The [=global attribution API flag=] for the current {{Window}} is true, or
 2.  The current {{Window}} has [=transient activation=] that can be [=consume user activation|consumed=].
-
-When the API is successfully invoked:
-1.  If [=transient activation=] was consumed, set the [=global attribution API flag=] to true.
 
 <p class=note>This approach allows a single user action to enable multiple
 API invocations within the same page session, while still requiring
@@ -1566,7 +1575,7 @@ and a [=moment=] |now|:
 
     1.  [=map/clear|Clear=] the [=epoch start store=].
 
-    <p class=issue>TODO: Define how to clear [=safety limits=] stores:
+    <p class=issue>TODO (issue https://github.com/w3c/attribution/issues/367): Define how to clear [=safety limits=] stores:
     [=global privacy budget store=] and [=impression site quota store=].
 
 1.  If |sites| [=set/is empty|is not empty=]:
@@ -1916,21 +1925,10 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
         1.  If |impressions| [=set/is empty|is not empty=]:
 
-            1.  Let |impressionsBySite| be a new [=map=].
-
-            1.  [=set/iterate|For each=] |impression| in |impressions|:
-
-                1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
-
-                1.  If |impressionsBySite| does not [=map/contain=] |impressionSite|,
-                    [=map/set=] |impressionsBySite|\[|impressionSite|] to an empty [=set=].
-
-                1.  [=set/Append=] |impression| to |impressionsBySite|\[|impressionSite|].
-
             1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
             1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-                with |key|, |epoch|, |impressionsBySite|,
+                with |key|, |epoch|, |impressions|,
                 |options|' [=validated conversion options/epsilon=],
                 |options|' [=validated conversion options/value=],
                 |options|'s [=validated conversion options/max value=],
@@ -2171,25 +2169,27 @@ will be a fixed value that is determined
 by the choice of technology used by the [=aggregation service=];
 it is not [=implementation-defined=].
 
-Deciding on a value for differential privacy parameters
+### Privacy and Safety Limit Parameter Configuration ### {#safety-limits-configuration}
+
+<p class=issue> Deciding on a value for differential privacy parameters
 is hard and therefore TBD.
 
-### Safety Limits Configuration ### {#safety-limits-configuration}
+[=User agents=] configure the [=privacy budget=] and [=safety limits=] by defining values
+for the following:  per-[=site=] [=privacy budget=] (&epsilon;<sub>site</sub>):
 
-[=User agents=] configure [=safety limits=] by defining values
-as multiples of the per-[=site=] [=privacy budget=] (&epsilon;<sub>site</sub>):
+*   The per-[=site=] [=privacy budget=] (&epsilon;<sub>site</sub>) within the range of: TBD
 
-*   <dfn>Global budget per epoch</dfn> (&epsilon;<sub>global</sub>):
-    The maximum privacy budget available across all [=sites=] per [=epoch=],
+*   The <dfn>global budget per epoch</dfn> (&epsilon;<sub>global</sub>) which is
+    the maximum privacy budget available across all [=sites=] per [=epoch=],
     specified in [=microepsilons=].
-    Implementations [=must=] set this value to at least 100 times
+    Implementations [=must=] set this value as a multiple of
     the per-[=site=] [=privacy budget=] per [=epoch=].
 
-*   <dfn>Impression site quota per epoch</dfn> (&epsilon;<sub>imp-quota</sub>):
-    The maximum privacy budget that a single [=impression site=]
+*   The <dfn>impression site quota per epoch</dfn> (&epsilon;<sub>imp-quota</sub>) which is
+    the maximum privacy budget that a single [=impression site=]
     can enable to be consumed from the [=global privacy budget store|global privacy budget=] per [=epoch=],
     specified in [=microepsilons=].
-    Implementations [=must=] set this value to at least 10 times
+    Implementations [=must=] set this value as a multiple of
     the per-[=site=] [=privacy budget=] per [=epoch=].
 
 <p class=note>Setting [=safety limits=] as multiples of the per-[=site=] budget

--- a/api.bs
+++ b/api.bs
@@ -1251,10 +1251,10 @@ a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
     1.  Let |impressionQuotaKey| be an [=impression site quota key=]
         whose items are |epoch| and |impressionSite|.
 
-1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|
-    and |siteDeduction| is greater than the [=impression site quota per epoch=], return false.
+    1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|
+        and |siteDeduction| is greater than the [=impression site quota per epoch=], return false.
 
-    1.  If |siteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
+    1.  If [=map/contains] |impressionQuotaKey| and |siteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
         return false.
 
 1.  Return true.

--- a/api.bs
+++ b/api.bs
@@ -1080,7 +1080,6 @@ that are used to manage the expenditure of [=privacy budgets=]:
 
 *   The [=privacy budget store=] records the state
     of the per-[=site=] and per-[=epoch=] [=privacy budgets=].
-    It is updated by [=deduct privacy budget=].
 
 *   The [=epoch start store=] records when each [=epoch=] starts
     for [=conversion sites=].
@@ -1096,6 +1095,10 @@ that are used to manage the expenditure of [=privacy budgets=]:
 
 *   The [=impression site quota store=] records the state
     of per-[=impression site=] and per-[=epoch=] quota [=privacy budgets=].
+
+*   The [=privacy budget store=], [=global privacy budget store=],
+    and [=impression site quota store=] are updated by [=deduct privacy and safety budgets=].
+
 
 <p class=note>
 Like the [=impression store=],
@@ -2187,7 +2190,7 @@ as multiples of the per-[=site=] [=privacy budget=] (&epsilon;<sub>site</sub>):
 
 *   <dfn>Impression site quota per epoch</dfn> (&epsilon;<sub>imp-quota</sub>):
     The maximum privacy budget that a single [=impression site=]
-    can enable to be consumed from the [=global privacy budget=] per [=epoch=],
+    can enable to be consumed from the [=global privacy budget store|global privacy budget=] per [=epoch=],
     specified in [=microepsilons=].
     Implementations [=must=] set this value to at least 10 times
     the per-[=site=] [=privacy budget=] per [=epoch=].
@@ -3114,7 +3117,7 @@ If the [=privacy budget=] for that [=epoch=] is not sufficient,
 the impressions from that [=epoch=] are not used.
 
 Each time a [=conversion site=] invokes <a method for=Attribution>measureConversion()</a>
-the [=deduct privacy budget|privacy budget is deducted=]
+the [=deduct privacy and safety budgets|privacy budget is deducted=]
 for [=epochs=] from which the [=attribution logic=] selected [=impressions=].
 
 <div class=example id=ex-budget>

--- a/api.bs
+++ b/api.bs
@@ -1147,8 +1147,6 @@ integer |value|,
 integer |maxValue|,
 boolean |isSingleEpoch| and integer |l1Norm|:
 
-1.  Let |epoch| be the [=epoch index=] component of |key|.
-
 1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
 
 1.  Let |valueSensitivity| be 2 * |value|.
@@ -1180,7 +1178,8 @@ boolean |isSingleEpoch| and integer |l1Norm|:
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
 
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
-    with |key|, |l1Normdeduction|, |valueDeduction|, |impressions|,
+    with |key|, |l1Normdeduction|, |valueDeduction|,
+    |impressions|, and |isSingleEpoch|,
     is false, return false.
 
 1.  All budget checks passed, so perform the deductions atomically:
@@ -1202,12 +1201,12 @@ how locking is performed to ensure atomicity across checks and deductions, but l
 
     1.  [=list/iterate|For each=] |impression| in |impressions|:
 
-        1. Let |impressionTime| be |impression|'s [=impression/impression time=]
+        1.  Let |impressionTime| be |impression|'s [=impression/timestamp=].
 
-        1. Let |impressionSite| be |impression|'s [=impression/impression site=].
+        1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-        1. Let |globalEpoch| be the result of [=get the current global epoch=]
-        with |impressionTime|.
+        1.  Let |globalEpoch| be the result of [=get the current global epoch=]
+            with |impressionTime|.
 
         1.  Let |impressionQuotaKey| be an [=impression site quota key=]
             whose items are |globalEpoch| and |impressionSite|.
@@ -1215,11 +1214,13 @@ how locking is performed to ensure atomicity across checks and deductions, but l
         1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
             [=map/set=] its value to the [=impression site quota per epoch=].
 
-        1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|, [=set/extend] |deductedImpressionQuotas| with |impressionQuotaKey|
-         and decrement [=impression site quota store=]\[|impressionQuotaKey|] by |valueDeduction|.
+        1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|,
+            [=set/extend=] |deductedImpressionQuotas| with |impressionQuotaKey|
+            and decrement [=impression site quota store=]\[|impressionQuotaKey|] by |valueDeduction|.
 
-        1.  If |deductedGlobalEpochs| does not [=map/contain=] |globalEpoch|, [=set/extend] |deductedGlobalEpochs| with |globalEpoch|
-         and decrement [=global privacy budget store=]\[|globalEpoch|] by |valueDeduction|.
+        1.  If |deductedGlobalEpochs| does not [=map/contain=] |globalEpoch|,
+            [=set/extend=] |deductedGlobalEpochs| with |globalEpoch|
+            and decrement [=global privacy budget store=]\[|globalEpoch|] by |valueDeduction|.
 
 1.  Return true.
 
@@ -1228,7 +1229,7 @@ how locking is performed to ensure atomicity across checks and deductions, but l
 <div algorithm>
 To <dfn>check for available privacy budget</dfn>
 given a [=privacy budget key=] |key|, integer |l1Normdeduction|,
-integer |valueDeduction|, an integer |impressionSiteDeduction|,
+integer |valueDeduction|,
 [=set=] of [=impressions=] |impressions| and boolean |isSingleEpoch|:
 
 1.  Let |currentValue| be set to the value of [=map/get|getting the value=] of |key|
@@ -1241,23 +1242,23 @@ integer |valueDeduction|, an integer |impressionSiteDeduction|,
 
 1.  [=list/iterate|For each=] |impression| in |impressions|:
 
-    1. Let |impressionTime| be |impression|'s [=impression/impression time=]
+    1.  Let |impressionTime| be |impression|'s [=impression/timestamp=].
 
-    1. Let |impressionSite| be |impression|'s [=impression/impression site=].
+    1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-    1. Let |globalEpoch| be the result of [=get the current global epoch=]
-    with |impressionTime|.
+    1.  Let |globalEpoch| be the result of [=get the current global epoch=]
+        with |impressionTime|.
 
-    1. Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
-    of |globalEpoch| from the [=global privacy budget store=], or the [=global privacy budget
-    per epoch=] if [=map/contain|no value has been set=].
+    1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
+        of |globalEpoch| from the [=global privacy budget store=], or the [=global privacy budget
+        per epoch=] if [=map/contain|no value has been set=].
 
-    1. Let |impressionQuotaKey| be an [=impression site quota key=]
-        whose items are |globalEpoch| and |impressionSite|
+    1.  Let |impressionQuotaKey| be an [=impression site quota key=]
+        whose items are |globalEpoch| and |impressionSite|.
 
-    1. Let |currentImpressionQuotaValue| be set to the value of [=map/get|getting the value=]
-    of |impressionQuotaKey| from the [=impression site quota store=],
-    or the [=impression site quota per epoch=] if [=map/contain|no value has been set=].
+    1.  Let |currentImpressionQuotaValue| be set to the value of [=map/get|getting the value=]
+        of |impressionQuotaKey| from the [=impression site quota store=],
+        or the [=impression site quota per epoch=] if [=map/contain|no value has been set=].
 
     1. If |valueDeduction| is greater than |currentGlobalValue| or greater than |currentImpressionQuotaValue|, return false.
 
@@ -1309,7 +1310,7 @@ that could be maliciously triggered.
 Each site has a separate cadence for the epochs of its per-[=site=] [=privacy budget store=].
 A separate global epoch cadence is shared by the [=global privacy budget store=] and all of the
  [=impression site quota stores|impression site quota store=].  This is to ensure there is
- no device-sepecific value shared across sites that could potentially be learned through
+ no device-specific value shared across sites that could potentially be learned through
  timing and side channel attacks.
 
 
@@ -1347,7 +1348,7 @@ The API can be invoked if either:
 <p class=note>This approach allows a single user action
 to enable multiple API invocations within the same session,
 while only making the API available to one site
-per [=activation triggering input event|activation=].
+per <a href="https://html.spec.whatwg.org/#activation-triggering-input-event">activation</a>.
 
 <div algorithm>
 To <dfn>check attribution API activation</dfn>,
@@ -1904,13 +1905,13 @@ To <dfn>do attribution and fill a histogram</dfn>, given
         with |options|, |topLevelSite|, |intermediarySite|, |currentEpoch|, and |now|.
 
     1.  If |matchedImpressions| [=set/is empty=], return the result of invoking
-    [=create an all-zero histogram=] with
-    |options|' [=validated conversion options/histogram size=].
+          [=create an all-zero histogram=] with
+          |options|' [=validated conversion options/histogram size=].
 
     1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
-    |options|' [=validated conversion options/histogram size=],
-    |options|' [=validated conversion options/value=], and
-    |options|' [=validated conversion options/credit=].
+        |options|' [=validated conversion options/histogram size=],
+        |options|' [=validated conversion options/value=], and
+        |options|' [=validated conversion options/credit=].
 
     1.  Let |l1Norm| be the sum of the [=list/items=] in |histogram|.
 
@@ -1936,13 +1937,13 @@ To <dfn>do attribution and fill a histogram</dfn>, given
             [=set/extend=] |matchedImpressions| with |impressions|.
 
 1.  If |matchedImpressions| [=set/is empty=], return the result of invoking
-[=create an all-zero histogram=] with
-|options|' [=validated conversion options/histogram size=].
+    [=create an all-zero histogram=] with
+    |options|' [=validated conversion options/histogram size=].
 
 1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
-|options|' [=validated conversion options/histogram size=],
-|options|' [=validated conversion options/value=], and
-|options|' [=validated conversion options/credit=].
+    |options|' [=validated conversion options/histogram size=],
+    |options|' [=validated conversion options/value=], and
+    |options|' [=validated conversion options/credit=].
 
 1.  Return |histogram|.
 

--- a/api.bs
+++ b/api.bs
@@ -1145,8 +1145,8 @@ given a [=privacy budget key=] |key|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|,
-boolean |isSingleEpoch|, integer |l1Norm|, [=set=] of [=impression quota keys=] |deductedImpressionQuotas|
-and a [=set=] of [=safety limit epoch indicies=] |deductedGlobalBudgets|:
+boolean |isSingleEpoch|, integer |l1Norm|, [=set=] of [=impression site quota keys=] |deductedImpressionQuotas|
+and a [=set=] of [=safety limit epoch indices=] |deductedGlobalBudgets|:
 
 1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
 
@@ -1171,8 +1171,8 @@ and a [=set=] of [=safety limit epoch indicies=] |deductedGlobalBudgets|:
 
 1.  Let |valueDeduction| be |valueDeductionFp| * 1000000, rounded towards positive Infinity.
 
-    <p class=note> One [=epoch=] (which is the epoch of the conversion site) can overlap with multiple [=safety limit epochs=] used by the [=global budget=]
-    and [=impression site quotas=]. We will look at each impression individually and map it to the [=safety limit epoch=] it is in to deduct from the global budget
+    <p class=note> One [=epoch=] (which is the epoch of the conversion site) can overlap with multiple [=safety limit epochs=] used by the [=global privacy budget store|global budget=]
+    and [=impression site quota store|impression site quotas=]. We will look at each impression individually and map it to the [=safety limit epoch=] it is in to deduct from the global budget
     and impression site quota if those have not already deducted from in this call to [=measure a conversion=].
 
 <p class=issue>TODO: Additional work to specify
@@ -1434,36 +1434,38 @@ returning an [=epoch index=]:
 
 </div>
 
-### Saftety Limit Epoch Start ### {#s-epoch-start}
+### Safety Limit Epoch Start ### {#s-safety-limit-epoch-start}
 A [=safety limit epoch=] starts at the same time for all devices.  This
 ensures that it does not create a device-specific value that could be learned
 through timing or other side-channel attacks.
 
 A <dfn>safety limit epoch</dfn> identifies a period of time. The length
-of a [=safety limit epoch=] is fixed at one [=day=]. The start time for an
-[=safetly limit epoch=] is defined relative to the [=Unix epoch=].
+of a [=safety limit epoch=] is fixed at one [=day=]. The start time for a
+[=safety limit epoch=] is defined relative to the [=Unix epoch=].
 
 An <dfn local-lt="safety limit epoch indices">safety limit epoch index</dfn> is an integer
 that refers to a given [=safety limit epoch=].
 An [=safety limit epoch index=] is used to access the
-[=global privacy budget store=] and the [=impression site quota stores=].
+[=global privacy budget store=] and the [=impression site quota store|impression site quota stores=].
 
-[=moment|Points in time=] are translated to an [=safety limit epoch index=]
-for the corresponding [=safetly limit epoch=]
-using the [=get the current safetly limit epoch=] algorithm.
+[=moment|Points in time=] are translated to a [=safety limit epoch index=]
+for the corresponding [=safety limit epoch=]
+using the [=get the current safety limit epoch=] algorithm.
 
 <div algorithm>
 To <dfn>get the current safety limit epoch</dfn>
 given [=moment=] |t|,
 returning a [=safety limit epoch index=]:
 
-1.  Let |period| be the [=duration=] of one [=epoch=].
+1.  Let |period| be the [=duration=] of one [=safety limit epoch=].
 
 1.  Let |start| be the [=Unix epoch=].
 
 1.  Let |elapsed| be (|t| − |start|) / |period|.
 
 1.  Return |elapsed| as an integer, rounded towards negative Infinity.
+
+</div>
 
 ### Last Browsing History Clear Time ### {#last-clear}
 
@@ -1948,7 +1950,7 @@ their safety limits deducted from more than once.
 1.  For each |epoch| from |currentEpoch| to |startEpoch|, inclusive:
 
     <p class=note> Epochs are processed sequentially starting from the most recent epoch
-    and going back in time as safety limit deductions may depleate from same safety limits as
+    and going back in time as safety limit deductions can depleate from same safety limits as
     the next epoch will need to check.
 
     1.  Let |impressions| be the result of invoking [=common matching logic=]
@@ -2970,11 +2972,12 @@ The first [[PPA-DP]] establishes the theory
 for on-device Individual DP accounting. The second [[PPA-DP-2]] expands the analysis to
 the mathematical privacy guarantees afforded by per-site budgets and by the global budget.
 
-The per-site budgets should be seen as the primary privacy protection. Per-site budgets should be configured to provide a meaningful DP guarantee. However, the analysis in [[PPA-DP-2]] identified two assumptions that limit these guarantees:
+The per-site budgets should be seen as the primary privacy protection. Per-site budgets should be configured to provide a meaningful DP guarantee.
+However, the analysis in [[PPA-DP-2]] identified two assumptions that limit these guarantees:
 
 1.  *No cross-site adaptivity in data generation.* A site's queryable data stream (impressions
-    and conversions) must be generated independently of past DP [=attribution results=] from other sites.
-1.  *No leakage through cross-site shared limits.* Queries from one site must not affect which
+    and conversions) <span class=allow-2119>must</span> be generated independently of past DP [=attribution results=] from other sites.
+1.  *No leakage through cross-site shared limits.* Queries from one site <span class=allow-2119>must not</span> affect which
     reports are emitted to others.
 
 In short, neither assumption can hold in practice.

--- a/api.bs
+++ b/api.bs
@@ -1210,8 +1210,8 @@ how locking is performed to ensure atomicity across checks and deductions, but l
         1.  Let |impressionQuotaKey| be an [=impression site quota key=]
             whose items are |epoch| and |impressionSite|.
 
-        1. If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
-           [=map/set=] its value to the [=impression site quota per epoch=].
+        1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
+            [=map/set=] its value to the [=impression site quota per epoch=].
 
         1.  Decrement [=impression site quota store=]\[|impressionQuotaKey|] by |siteDeduction|.
 
@@ -1377,7 +1377,7 @@ throwing a {{"NotAllowedError"}} {{DOMException}} on failure:
 
     1.  Return.
 
-1.  [=Throw=] a {{"NotAllowedError"}} {{DOMException}}.
+1.  Throw a {{"NotAllowedError"}} {{DOMException}}.
 
 </div>
 

--- a/api.bs
+++ b/api.bs
@@ -1185,7 +1185,7 @@ nullable integer |l1Norm|:
 1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
 1.  Let |impSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
-    with |impressionsByImpSite| and |deduction|.
+    with |impressionsByImpSite|, |deduction|, |value|, |l1Norm|
 
 1.  Check that sufficient budget exists in all relevant stores
     before deducting from any of them.
@@ -1234,14 +1234,13 @@ given a [=map=] |impressionsByImpSite| from [=impression sites=] to [=sets=] of 
 and integer |deduction|:
 
 1. Let |impSiteDeductions| be a new [=map=].
+
 1. Let |numberImpressionSites| be the number of impression sites in |impressionsByImpSite|.
 
+1. Let |singleEpoch| be true if |l1Norm| is non-null, false otherwise.
+
 1.  [=map/iterate|For each=] |impSite| → |impressions| in |impressionsByImpSite|:
-
-    1.  If |impressions| [=set/is empty=]:
-        1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to 0.
-
-    1.  else if |singleEpoch| is true and |numImpressionSites| is 1:
+    1.  If |singleEpoch| is true and |numImpressionSites| is 1:
         1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |deduction|.
     1. else
         <p class=note> In this case we need to use the global sensitivity which is the value of |deduction| only in the multi-epoch case;
@@ -1251,6 +1250,7 @@ and integer |deduction|:
         1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
 
         1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
+
         1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
 
         1.  [=map/Set=] |impSiteDeductions|\[|impSite|] to |deduction|

--- a/api.bs
+++ b/api.bs
@@ -1280,7 +1280,7 @@ boolean |isSingleEpoch|:
 
 1.  Let |numberImpressionSites| be the [=set/size|number of impression sites=] in |impressionSites|.
 
-1.  [=map/iterate|For each=] |impressionSite| in |impressionsBySite|:
+1.  [=map/iterate|For each=] |impressionSite| in |impressionSites|:
 
     1.  If |isSingleEpoch| is true and |numberImpressionSites| is 1:
 

--- a/api.bs
+++ b/api.bs
@@ -1181,16 +1181,15 @@ nullable integer |l1Norm|:
 
 1.  Let |isSingleEpoch| be true if |l1Norm| is non-null, false otherwise.
 
-1.  Let |impressionSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
+1.  Let |impressionSiteDeduction| be the result of [=compute impression site deductions|computing impression site deductions=]
     with |impressionSites|, |deduction|, |value|, |maxValue|, |epsilon|, and |isSingleEpoch|.
 
 <p class=issue>TODO: Additional work to specify
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
 
-1.  Let |budgetAvailable| be the result of [=check for available privacy budget|checking for available privacy budget=]
-    with |key|, |deduction|, and |impressionSiteDeductions|.
-
-1.  If |budgetAvailable| is false, return false.
+1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
+    with |key|, |deduction|, and |impressionSiteDeductions|
+    is false, return false.
 
 1.  All budget checks passed, so perform the deductions atomically:
 
@@ -1202,7 +1201,7 @@ how locking is performed to ensure atomicity across checks and deductions, but l
 
     1.  Decrement [=global privacy budget store=]\[|epoch|] by |deduction|.
 
-    1.  [=map/iterate|For each=] |impressionSite| → |siteDeduction| in |impressionSiteDeductions|:
+    1.  [=map/iterate|For each=] |impressionSite|  in |impressionSites|:
 
         1.  Let |impressionQuotaKey| be an [=impression site quota key=]
             whose items are |epoch| and |impressionSite|.
@@ -1210,7 +1209,7 @@ how locking is performed to ensure atomicity across checks and deductions, but l
         1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
             [=map/set=] its value to the [=impression site quota per epoch=].
 
-        1.  Decrement [=impression site quota store=]\[|impressionQuotaKey|] by |siteDeduction|.
+        1.  Decrement [=impression site quota store=]\[|impressionQuotaKey|] by |impressionSiteDeduction|.
 
 1.  Return true.
 
@@ -1220,31 +1219,25 @@ how locking is performed to ensure atomicity across checks and deductions, but l
 To <dfn>check for available privacy budget</dfn>
 given a [=privacy budget key=] |key|,
 integer |deduction|, and
-a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
+an integer |impressionSiteDeduction|
+and a set |impressionSites| of [=impression sites=],:
 
-1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
-    its value of |key| to be a [=user agent=]-defined value,
-    plus 1000.
-
-    <p class=note>The addition of 1000 to this value
-    ensures that the rounding errors added by this algorithm do not cause
-    the budget to be exceeded unnecessarily after multiple invocations.
-    The privacy loss from the additional one-thousandth of an epsilon is trivial.
-
-1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
-    in the [=privacy budget store=].
+1.  Let |currentValue| be set to the value of [=map/get|getting the value=] of |key|
+    from [=privacy budget store=], or the [=per-site privacy budget=]
+    if [=map/contain|no value has been set=].
 
 1.  If |deduction| is greater than |currentValue|, return false.
 
 1.  Let |epoch| be the [=epoch index=] component of |key|.
 
-1.  If the [=global privacy budget store=] does not [=map/contain=] |epoch|,
-    [=map/set=] its value to the [=global budget per epoch=].
+1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
+    of |epoch| from the [=global privacy budget store=], or the [=global privacy budget
+    per epoch=] if [=map/contain|no value has been set=].
 
-1.  If |deduction| is greater than [=global privacy budget store=]\[|epoch|],
+1.  If |deduction| is greater than |currentGlobalValue|,
     return false.
 
-1.  [=map/iterate|For each=] |impressionSite| → |siteDeduction| in |impressionSiteDeductions|:
+1.  [=map/iterate|For each=] |impressionSite| in |impressionSites|:
 
     1.  Let |impressionQuotaKey| be an [=impression site quota key=]
         whose items are |epoch| and |impressionSite|.
@@ -1252,8 +1245,8 @@ a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
     1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|
         and |siteDeduction| is greater than the [=impression site quota per epoch=], return false.
 
-    1.  If [=map/contains=] |impressionQuotaKey| and |siteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
-        return false.
+    1.  If [=map/contains=] |impressionQuotaKey| and |impressionSiteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
+            return false.
 
 1.  Return true.
 
@@ -1267,8 +1260,6 @@ integer |value|,
 integer |maxValue|,
 [[WEBIDL#idl-double|double]] |epsilon|, and
 boolean |isSingleEpoch|:
-
-1.  Let |impressionSiteDeductions| be a new [=map=].
 
 1.  Let |sensitivity| be 2 * |value|.
 
@@ -1284,18 +1275,14 @@ boolean |isSingleEpoch|:
 
     1.  If |isSingleEpoch| is true and |numberImpressionSites| is 1:
 
-        1.  [=map/Set=] |impressionSiteDeductions|\[|impressionSite|] to |deduction|.
-
-        1.  Return |impressionSiteDeductions|.
+        1.  Return |deduction|.
 
     1.  Otherwise:
 
         <p class=note>In this case we need to use the global sensitivity which is the value of |deduction| only in the multi-epoch case;
         so we need to recompute it in case we are in the single epoch but multiple impression sites case.
 
-        1.  [=map/Set=] |impressionSiteDeductions|\[|impressionSite|] to |globalDeduction|.
-
-1.  Return |impressionSiteDeductions|.
+        1.  Return |globalDeduction|.
 
 </div>
 
@@ -1343,9 +1330,7 @@ that could be maliciously triggered.
 
 ### Attribution API Activation ### {#s-api-activation}
 
-The Attribution API requires user activation to prevent abuse. Examples of user activations
-that could be used to activate the API include
-<a href="https://html.spec.whatwg.org/#user-navigation-involvement">user navigation involvement</a> or clicks on the page.
+The Attribution API is a [=transient activation-consuming API=].
 The web platform uses <a href="https://html.spec.whatwg.org/#tracking-user-activation">transient activation</a> to limit the amount of time that a
 user activation remains available for calling certain user activation-gated APIs.
 The Attribution API can be activated by transient activation,
@@ -1373,12 +1358,10 @@ The API can be invoked if either:
 1.  The [=global attribution API flag=] for the current {{Window}} is true, or
 2.  The current {{Window}} has [=transient activation=] that can be [=consume user activation|consumed=].
 
-<p class=note>This approach allows a single user action to enable multiple
-API invocations within the same session, while still requiring
-an initial user gesture to activate the API.
-
-<p class=issue>TODO: Define how long the [=global attribution API flag=] remains true
-and under what conditions it should be reset (e.g., navigation, page lifecycle events).
+<p class=note>This approach allows a single user action
+to enable multiple API invocations within the same session,
+while only making the API available to one site
+per [=activation triggering input event|activation=].
 
 <div algorithm>
 To <dfn>check attribution API activation</dfn>,
@@ -1398,7 +1381,6 @@ throwing a {{"NotAllowedError"}} {{DOMException}} on failure:
 1.  Throw a {{"NotAllowedError"}} {{DOMException}}.
 
 </div>
-
 
 
 ### Epoch Start Store ### {#s-epoch-start}
@@ -1692,8 +1674,8 @@ and [=implicit API inputs=] |implicitInputs|:
          ::  |options|.{{AttributionImpressionOptions/histogramIndex}}
          :   [=impression/Priority=]
          ::  |options|.{{AttributionImpressionOptions/priority}}
-     1.  If the Attribution API is [[#opt-out|enabled]]:
-         1.  Save |impression| to the [=impression store=].
+     1.  If the Attribution API is [[#opt-out|enabled]],
+        save |impression| to the [=impression store=].
 
 1.  Let |result| be a new {{AttributionImpressionResult}}.
 1.  Return [=a promise resolved with=] |result| in |realm|.
@@ -2180,8 +2162,8 @@ it is not [=implementation-defined=].
 <p class=issue> Deciding on a value for differential privacy parameters
 is hard and therefore TBD.
 
-[=User agents=] configure the [=privacy budget=] and [=safety limits=] by defining values
-for the following:  per-[=site=] [=privacy budget=] (&epsilon;<sub>site</sub>):
+<dfn>Privacy Parameters</dfn>: [=User agents=] configure the [=privacy budget=] and [=safety limits=] by defining values
+for the following:
 
 *   The per-[=site=] [=privacy budget=] (&epsilon;<sub>site</sub>) within the range of: TBD
 

--- a/api.bs
+++ b/api.bs
@@ -1346,7 +1346,28 @@ that could be maliciously triggered.
 
 ### Attribution API Activation ### {#s-api-activation}
 
-The Attribution API requires user activation to prevent abuse.
+The Attribution API requires user activation to prevent abuse. Examples of user activations
+that could be used to activate the API include
+<a href="https://html.spec.whatwg.org/#user-navigation-involvement">user navigation involvement</a> or clicks on the page.
+The web platform uses <a href="https://html.spec.whatwg.org/#tracking-user-activation">transient activation</a> to limit the amount of time that a
+user activation remains available for calling certain user activation-gated APIs.
+The Attribution API can be activated by transient activation,
+and within the time window of a user action, the site can redirect to another site
+that will be able to use the transient activation if the first site has not consumed it.
+
+A couple of notes:
+
+1.  Since calling the Attribution API consumes a user activation, the site would no longer have this
+    particular user activation to use for other APIs (e.g., opening popups).
+
+1.  One common web pattern related to web advertising is for an advertiser site to have the user
+    click on a purchase button and be taken to a separate payment processor page. In such a scenario,
+    both sites will be able to use the API if the first site has used a different, earlier user action
+    to activate the API for that site (setting the window's [=global attribution API flag=] to true)
+    and then the second site uses the transient activation from the click to activate the API for
+    its use. But no further sites will be able to use the API without further user action in order
+    to prevent abuse.
+
 A <dfn>global attribution API flag</dfn> is associated with each {{Window}} object.
 The [=global attribution API flag=] is enabled whenever the API is successfully invoked.
 This flag is initially false.
@@ -1380,6 +1401,8 @@ throwing a {{"NotAllowedError"}} {{DOMException}} on failure:
 1.  Throw a {{"NotAllowedError"}} {{DOMException}}.
 
 </div>
+
+
 
 ### Epoch Start Store ### {#s-epoch-start}
 

--- a/api.bs
+++ b/api.bs
@@ -1253,19 +1253,44 @@ limiting its ability to rapidly deplete the [=global privacy budget=].
 ### User Action Context Store ### {#s-user-action-context-store}
 
 The <dfn>user action context store</dfn> is a [=map=] keyed by [=user action contexts=]
-and containing values that are [=sets=] of [=sites=].
+and containing values that are [=user action context entries=].
 
 A <dfn>user action context</dfn> is an identifier
 for a sequence of API invocations
 that are associated with a single intentional user action,
 such as a navigation or click.
 
+A <dfn>user action context entry</dfn> is a [=struct=] with the following fields:
+
+<dl dfn-for="user action context entry">
+: <dfn>Allowed Impression Sites</dfn>
+:: A [=set=] of [=impression sites=] that have been permitted
+   to save [=impressions=] within this [=user action context=].
+: <dfn>Impression Site Counter</dfn>
+:: A non-negative integer representing the remaining number of
+   new [=impression sites=] that may save [=impressions=]
+   within this [=user action context=].
+   Initialized to an [=implementation-defined=] <dfn>impression site count cap</dfn>.
+: <dfn>Allowed Conversion Sites</dfn>
+:: A [=map=] keyed by [=epoch index=] and containing values that are [=sets=]
+   of [=conversion sites=] that have been permitted to measure [=conversions=]
+   within this [=user action context=] for that [=epoch=].
+: <dfn>Conversion Site Counters</dfn>
+:: A [=map=] keyed by [=epoch index=] and containing values that are
+   non-negative integers representing the remaining number of
+   new [=conversion sites=] that may measure [=conversions=]
+   within this [=user action context=] for that [=epoch=].
+   Each counter is initialized to an [=implementation-defined=] <dfn>conversion site count cap</dfn>.
+</dl>
+
 The [=user action context store=] tracks which [=sites=]
 have accessed quota [=privacy budgets=]
 (either [=impression site quota store|impression site quotas=]
 or [=conversion site quota store|conversion site quotas=])
 within the current [=user action context=].
-This enables enforcement of the [=quota count cap=].
+This enables enforcement of site count caps,
+limiting the number of distinct sites that can participate
+in attribution within a single user action.
 
 <p class=note>A [=user action context=] typically corresponds to
 a top-level navigation or other substantial user interaction.
@@ -1280,13 +1305,80 @@ returning a [=user action context=]:
     associated with the current execution context, return it.
 
 1.  Otherwise, create a new [=user action context=] identifier,
-    add it to the [=user action context store=] with an empty [=set=] value,
-    and return it.
+    create a new [=user action context entry=] with:
+    *   [=user action context entry/Allowed Impression Sites=] set to an empty [=set=],
+    *   [=user action context entry/Impression Site Counter=] set to the [=impression site count cap=],
+    *   [=user action context entry/Allowed Conversion Sites=] set to an empty [=map=],
+    *   [=user action context entry/Conversion Site Counters=] set to an empty [=map=],
+
+    add the identifier and entry to the [=user action context store=],
+    and return the identifier.
 
 <p class=note>The [=user agent=] determines when [=user action contexts=] expire
 and are removed from the [=user action context store=].
 Contexts typically expire after some period of inactivity
 or when a new top-level navigation occurs.
+
+</div>
+
+<div algorithm>
+To <dfn>check impression site allowance</dfn>,
+given an [=impression site=] |impSite|
+and a [=user action context=] |uaContext|,
+returning a [=boolean=]:
+
+1.  Let |entry| be the result of [=map/get|getting=] |uaContext|
+    from the [=user action context store=].
+
+1.  If |entry|'s [=user action context entry/Allowed Impression Sites=]
+    [=set/contains=] |impSite|, return true.
+
+1.  If |entry|'s [=user action context entry/Impression Site Counter=] is 0,
+    return false.
+
+1.  [=set/Append=] |impSite| to |entry|'s
+    [=user action context entry/Allowed Impression Sites=].
+
+1.  Decrement |entry|'s [=user action context entry/Impression Site Counter=] by 1.
+
+1.  Return true.
+
+</div>
+
+<div algorithm>
+To <dfn>check conversion site allowance</dfn>,
+given a [=conversion site=] |convSite|,
+an [=epoch index=] |epoch|,
+and a [=user action context=] |uaContext|,
+returning a [=boolean=]:
+
+1.  Let |entry| be the result of [=map/get|getting=] |uaContext|
+    from the [=user action context store=].
+
+1.  If |entry|'s [=user action context entry/Conversion Site Counters=]
+    does not [=map/contain=] |epoch|:
+
+    1.  [=map/Set=] |entry|'s [=user action context entry/Conversion Site Counters=]\[|epoch|]
+        to the [=conversion site count cap=].
+
+    1.  [=map/Set=] |entry|'s [=user action context entry/Allowed Conversion Sites=]\[|epoch|]
+        to an empty [=set=].
+
+1.  Let |allowedSites| be the result of [=map/get|getting=] |epoch|
+    from |entry|'s [=user action context entry/Allowed Conversion Sites=].
+
+1.  If |allowedSites| [=set/contains=] |convSite|, return true.
+
+1.  Let |counter| be the result of [=map/get|getting=] |epoch|
+    from |entry|'s [=user action context entry/Conversion Site Counters=].
+
+1.  If |counter| is 0, return false.
+
+1.  [=set/Append=] |convSite| to |allowedSites|.
+
+1.  Decrement |entry|'s [=user action context entry/Conversion Site Counters=]\[|epoch|] by 1.
+
+1.  Return true.
 
 </div>
 
@@ -1560,6 +1652,7 @@ The <dfn method for=Attribution>saveImpression(|options|)</dfn> method steps are
         1.   otherwise, the result of
              [=obtain a site|obtaining a site=]
              from |settings|' [=environment settings object/origin=].
+    1.  Let |uaContext| be the [=current user action context=].
 1.  Validate the page-supplied API inputs:
     1.  If |options|.{{AttributionImpressionOptions/histogramIndex}} is
         greater than or equal to the [=implementation-defined=] [=maximum histogram size=],
@@ -1606,8 +1699,10 @@ The <dfn method for=Attribution>saveImpression(|options|)</dfn> method steps are
          ::  |options|.{{AttributionImpressionOptions/histogramIndex}}
          :   [=impression/Priority=]
          ::  |options|.{{AttributionImpressionOptions/priority}}
-     1.  If the Attribution API is [[#opt-out|enabled]],
-         save |impression| to the [=impression store=].
+     1.  If the Attribution API is [[#opt-out|enabled]]:
+         1.  Let |allowed| be the result of [=check impression site allowance|checking impression site allowance=]
+             given |site| and |uaContext|.
+         1.  If |allowed| is true, save |impression| to the [=impression store=].
 
 1.  Let |result| be a new {{AttributionImpressionResult}}.
 1.  Return [=a promise resolved with=] |result| in |realm|.

--- a/api.bs
+++ b/api.bs
@@ -1175,45 +1175,18 @@ nullable integer |l1Norm|:
 1.  Let |impressionSiteDeductions| be the result of [=compute impression site deductions|computing impression site deductions=]
     with |impressionsBySite|, |deduction|, |value|, |maxValue|, |epsilon|, and |l1Norm|.
 
-1.  Check that sufficient budget exists in all relevant stores
-    before deducting from any of them.
-    This ensures atomicity: either all deductions succeed, or none occur.
+<p class=issue>TODO: Additional work to specify
+how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
 
-    <p class=issue>TODO: This section needs additional work to specify
-    how locking is performed to ensure atomicity across multiple stores.
+1.  Let |budgetAvailable| be the result of [=check for available privacy budget|checking for available privacy budget=]
+    with |key|, |epoch|, |deduction|, and |impressionSiteDeductions|.
 
-    1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
-        in the [=privacy budget store=].
-
-    1.  If |deduction| is greater than |currentValue|, return false.
-
-    1.  If the [=global privacy budget store=] does not [=map/contain=] |epoch|,
-        [=map/set=] its value to the [=global budget per epoch=].
-
-    1.  If |deduction| is greater than [=global privacy budget store=]\[|epoch|],
-        return false.
-
-    1.  [=map/iterate|For each=] |impressionSite| → |siteDeduction| in |impressionSiteDeductions|:
-
-        1.  Let |impQuotaKey| be an [=impression site quota key=]
-            whose items are |epoch| and |impressionSite|.
-
-        1.  If the [=impression site quota store=] does not [=map/contain=] |impQuotaKey|, compare |siteDeduction| to the value of
-            [=impression site quota per epoch=] and if it is greater, return false.
-
-        1.  If |siteDeduction| is greater than [=impression site quota store=]\[|impQuotaKey|],
-            return false.
+1.  If |budgetAvailable| is false, return false.
 
 1.  All budget checks passed, so perform the deductions atomically:
 
-    1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
-        its value of |key| to be a [=user agent=]-defined value,
-        plus 1000.
-
-    <p class=note>The addition of 1000 to this value
-    ensures that the rounding errors added by this algorithm do not cause
-    the budget to be exceeded unnecessarily after multiple invocations.
-    The privacy loss from the additional one-thousandth of an epsilon is trivial.
+    1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
+        in the [=privacy budget store=].
 
     1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
         to |currentValue| − |deduction|.
@@ -1222,10 +1195,53 @@ nullable integer |l1Norm|:
 
     1.  [=map/iterate|For each=] |impressionSite| → |siteDeduction| in |impressionSiteDeductions|:
 
-        1.  Let |impQuotaKey| be an [=impression site quota key=]
+        1.  Let |impressionQuotaKey| be an [=impression site quota key=]
             whose items are |epoch| and |impressionSite|.
 
-        1.  Decrement [=impression site quota store=]\[|impQuotaKey|] by |siteDeduction|.
+        1.  Decrement [=impression site quota store=]\[|impressionQuotaKey|] by |siteDeduction|.
+
+1.  Return true.
+
+</div>
+
+<div algorithm>
+To <dfn>check for available privacy budget</dfn>
+given a [=privacy budget key=] |key|,
+[=epoch index=] |epoch|,
+integer |deduction|, and
+a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
+
+1.  If the [=privacy budget store=] does not [=map/contain=] |key|, [=map/set=]
+    its value of |key| to be a [=user agent=]-defined value,
+    plus 1000.
+
+    <p class=note>The addition of 1000 to this value
+    ensures that the rounding errors added by this algorithm do not cause
+    the budget to be exceeded unnecessarily after multiple invocations.
+    The privacy loss from the additional one-thousandth of an epsilon is trivial.
+
+1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
+    in the [=privacy budget store=].
+
+1.  If |deduction| is greater than |currentValue|, return false.
+
+1.  If the [=global privacy budget store=] does not [=map/contain=] |epoch|,
+    [=map/set=] its value to the [=global budget per epoch=].
+
+1.  If |deduction| is greater than [=global privacy budget store=]\[|epoch|],
+    return false.
+
+1.  [=map/iterate|For each=] |impressionSite| → |siteDeduction| in |impressionSiteDeductions|:
+
+    1.  Let |impressionQuotaKey| be an [=impression site quota key=]
+        whose items are |epoch| and |impressionSite|.
+
+    1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
+        compare |siteDeduction| to the value of [=impression site quota per epoch=]
+        and if it is greater, return false.
+
+    1.  If |siteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
+        return false.
 
 1.  Return true.
 

--- a/api.bs
+++ b/api.bs
@@ -1144,20 +1144,23 @@ given a [=privacy budget key=] |key|,
 [=set=] of [=impressions=] |impressions|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
-integer |maxValue|, and
-nullable integer |l1Norm|:
+integer |maxValue|,
+boolean |isSingleEpoch| and integer |l1Norm|:
 
 1.  Let |epoch| be the [=epoch index=] component of |key|.
 
-1.  Let |sensitivity| be |l1Norm| if |l1Norm| is non-null, 2 * |value| otherwise.
+1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
+
+1.  Let |valueSensitivity| be 2 * |value|.
 
 1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
 
-1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
+1.  Let |l1NormDeductionFp| be |l1NormSensitivity| / |noiseScale|.
+
+1.  Let |valueDeductionFp| be |valueSensitivity| / |noiseScale|.
 
 
-    <p class=note>Single epoch attributions &mdash;
-    the only case that |l1Norm| is non-null &mdash;
+    <p class=note> Single epoch attributions
     do not cause any cascading effects across epochs.
     Attribution that involves multiple epochs consumes double the budget
     because of the potential for one change to affect attribution across epochs.
@@ -1165,30 +1168,19 @@ nullable integer |l1Norm|:
     proportional to |maxValue| / |epsilon|
     is added to the aggregated histogram.
 
-1.  If |deductionFp| is negative or greater than [=maximum epsilon=],
-    [=map/set|set=] the value of |key| in the [=privacy budget store=] to 0
-    and return false.
+1.  Let |l1Normdeduction| be |l1NormDeductionFp| * 1000000, rounded towards positive Infinity.
 
-1.  Let |deduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
+1.  Let |valueDeduction| be |valueDeductionFp| * 1000000, rounded towards positive Infinity.
 
-1.  Let |impressionSites| be a new [=set=].
-
-1.  [=set/iterate|For each=] |impression| in |impressions|:
-
-    1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
-
-    1.  [=set/append=] |impressionSite| to |impressionSites|.
-
-1.  Let |isSingleEpoch| be true if |l1Norm| is non-null, false otherwise.
-
-1.  Let |impressionSiteDeduction| be the result of [=compute impression site deductions|computing impression site deductions=]
-    with |impressionSites|, |deduction|, |value|, |maxValue|, |epsilon|, and |isSingleEpoch|.
+    <p class=note> One epoch (which is the epoch of the conversion site) may overlap with multiple global epochs used by the global budget
+    and cross-site quotas. We will look at each impression individually and map it to the global epoch it is in to deduct from the global budget
+    and impression site quota if those have not already deducted from in this epoch.
 
 <p class=issue>TODO: Additional work to specify
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
 
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
-    with |key|, |deduction|, |impressionSites|, and |impressionSiteDeduction|
+    with |key|, |l1Normdeduction|, |valueDeduction|, |impressions|,
     is false, return false.
 
 1.  All budget checks passed, so perform the deductions atomically:
@@ -1199,20 +1191,35 @@ how locking is performed to ensure atomicity across checks and deductions, but l
     1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
         in the [=privacy budget store=].
 
+    1.  If |isSingleEpoch| let |deduction| be |l1Normdeduction| else let |deduction| be |valueDeduction|
+
     1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
         to |currentValue| − |deduction|.
 
-    1.  Decrement [=global privacy budget store=]\[|epoch|] by |deduction|.
+    1.  Let |deductedImpressionQuotas| be a new [=set=].
 
-    1.  [=map/iterate|For each=] |impressionSite|  in |impressionSites|:
+    1.  Let |deductedGlobalEpochs| be a new [=set=].
+
+    1.  [=list/iterate|For each=] |impression| in |impressions|:
+
+        1. Let |impressionTime| be |impression|'s [=impression/impression time=]
+
+        1. Let |impressionSite| be |impression|'s [=impression/impression site=].
+
+        1. Let |globalEpoch| be the result of [=get the current global epoch=]
+        with |impressionTime|.
 
         1.  Let |impressionQuotaKey| be an [=impression site quota key=]
-            whose items are |epoch| and |impressionSite|.
+            whose items are |globalEpoch| and |impressionSite|.
 
         1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
             [=map/set=] its value to the [=impression site quota per epoch=].
 
-        1.  Decrement [=impression site quota store=]\[|impressionQuotaKey|] by |impressionSiteDeduction|.
+        1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|, [=set/extend] |deductedImpressionQuotas| with |impressionQuotaKey|
+         and decrement [=impression site quota store=]\[|impressionQuotaKey|] by |valueDeduction|.
+
+        1.  If |deductedGlobalEpochs| does not [=map/contain=] |globalEpoch|, [=set/extend] |deductedGlobalEpochs| with |globalEpoch|
+         and decrement [=global privacy budget store=]\[|globalEpoch|] by |valueDeduction|.
 
 1.  Return true.
 
@@ -1220,73 +1227,43 @@ how locking is performed to ensure atomicity across checks and deductions, but l
 
 <div algorithm>
 To <dfn>check for available privacy budget</dfn>
-given a [=privacy budget key=] |key|,
-integer |deduction|, and
-an integer |impressionSiteDeduction|
-and a set |impressionSites| of [=impression sites=],:
+given a [=privacy budget key=] |key|, integer |l1Normdeduction|,
+integer |valueDeduction|, an integer |impressionSiteDeduction|,
+[=set=] of [=impressions=] |impressions| and boolean |isSingleEpoch|:
 
 1.  Let |currentValue| be set to the value of [=map/get|getting the value=] of |key|
     from [=privacy budget store=], or the [=per-site privacy budget=]
     if [=map/contain|no value has been set=].
 
+1.  If |isSingleEpoch| let |deduction| be |l1Normdeduction| else let |deduction| be |valueDeduction|
+
 1.  If |deduction| is greater than |currentValue|, return false.
 
-1.  Let |epoch| be the [=epoch index=] component of |key|.
+1.  [=list/iterate|For each=] |impression| in |impressions|:
 
-1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
-    of |epoch| from the [=global privacy budget store=], or the [=global privacy budget
+    1. Let |impressionTime| be |impression|'s [=impression/impression time=]
+
+    1. Let |impressionSite| be |impression|'s [=impression/impression site=].
+
+    1. Let |globalEpoch| be the result of [=get the current global epoch=]
+    with |impressionTime|.
+
+    1. Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
+    of |globalEpoch| from the [=global privacy budget store=], or the [=global privacy budget
     per epoch=] if [=map/contain|no value has been set=].
 
-1.  If |deduction| is greater than |currentGlobalValue|,
-    return false.
+    1. Let |impressionQuotaKey| be an [=impression site quota key=]
+        whose items are |globalEpoch| and |impressionSite|
 
-1.  [=map/iterate|For each=] |impressionSite| in |impressionSites|:
+    1. Let |currentImpressionQuotaValue| be set to the value of [=map/get|getting the value=]
+    of |impressionQuotaKey| from the [=impression site quota store=],
+    or the [=impression site quota per epoch=] if [=map/contain|no value has been set=].
 
-    1.  Let |impressionQuotaKey| be an [=impression site quota key=]
-        whose items are |epoch| and |impressionSite|.
-
-    1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|
-        and |impressionSiteDeduction| is greater than the [=impression site quota per epoch=], return false.
-
-    1.  If [=map/contains=] |impressionQuotaKey| and |impressionSiteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
-            return false.
+    1. If |valueDeduction| is greater than |currentGlobalValue| or greater than |currentImpressionQuotaValue|, return false.
 
 1.  Return true.
 
 </div>
-
-<div algorithm>
-To <dfn>compute impression site deductions</dfn>
-given an set |impressionSites| of [=impression sites=],
-integer |deduction|,
-integer |value|,
-integer |maxValue|,
-[[WEBIDL#idl-double|double]] |epsilon|, and
-boolean |isSingleEpoch|:
-
-1.  Let |sensitivity| be 2 * |value|.
-
-1.  Let |noiseScale| be 2 * |maxValue| / |epsilon|.
-
-1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
-
-1.  Let |globalDeduction| be |deductionFp| * 1000000, rounded towards positive Infinity.
-
-1.  Let |numberImpressionSites| be the [=set/size|number of impression sites=] in |impressionSites|.
-
-1.  If |isSingleEpoch| is true and |numberImpressionSites| is 1:
-
-    1.  Return |deduction|.
-
-1.  Otherwise:
-
-    <p class=note>In this case we need to use the global sensitivity which is the value of |deduction| only in the multi-epoch case;
-        so we need to recompute it in case we are in the single epoch but multiple impression sites case.
-
-    1.  Return |globalDeduction|.
-
-</div>
-
 
 
 ### Global Privacy Budget Store ### {#s-global-privacy-budget-store}
@@ -1327,6 +1304,14 @@ that any single [=impression site=] can contribute in an [=epoch=].
 This prevents a single [=impression site=]
 from enabling excessive budget
 that could be maliciously triggered.
+
+### Epoch Cadences ### {#s-epoch-cadences}
+Each site has a separate cadence for the epochs of its per-[=site=] [=privacy budget store=].
+A separate global epoch cadence is shared by the [=global privacy budget store=] and all of the
+ [=impression site quota stores|impression site quota store=].  This is to ensure there is
+ no device-sepecific value shared across sites that could potentially be learned through
+ timing and side channel attacks.
+
 
 
 ### Attribution API Activation ### {#s-api-activation}
@@ -1912,59 +1897,52 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 1.  Let |earliestEpoch| be the result of calling [=get the current epoch=],
     passing |topLevelSite| and (|now| − |options|' [=validated conversion options/lookback=]).
 
-1.  Let |singleEpoch| be true if |currentEpoch| is equal to |earliestEpoch|, false otherwise.
+1.  Let |isSingleEpoch| be true if |currentEpoch| is equal to |earliestEpoch|, false otherwise.
 
-1.  If |singleEpoch| is true:
+1.  If |isSingleEpoch| is true:
     1.  Set |matchedImpressions| to the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |currentEpoch|, and |now|.
 
-1.  If |singleEpoch| is false:
-    1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
-
-        1.  Let |impressions| be the result of invoking [=common matching logic=]
-            with |options|, |topLevelSite|, |intermediarySite|, |epoch|, and |now|.
-
-        1.  If |impressions| [=set/is empty|is not empty=]:
-
-            1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
-
-            1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-                with |key|, |impressions|,
-                |options|' [=validated conversion options/epsilon=],
-                |options|' [=validated conversion options/value=],
-                |options|'s [=validated conversion options/max value=],
-                and null.
-
-            1.  If |budgetAndSafetyOk| is true,
-                [=set/extend=] |matchedImpressions| with |impressions|.
-
-
-
-1.  If |matchedImpressions| [=set/is empty=], return the result of invoking
+    1.  If |matchedImpressions| [=set/is empty=], return the result of invoking
     [=create an all-zero histogram=] with
     |options|' [=validated conversion options/histogram size=].
 
-1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
+    1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
     |options|' [=validated conversion options/histogram size=],
     |options|' [=validated conversion options/value=], and
     |options|' [=validated conversion options/credit=].
 
-1.  If |singleEpoch| is true:
     1.  Let |l1Norm| be the sum of the [=list/items=] in |histogram|.
 
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
 
-    1.  Let |key| be a [=privacy budget key=] whose items are |currentEpoch| and |topLevelSite|.
+1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
 
-    1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-        with |key|, |matchedImpressions|,
-        |options|' [=validated conversion options/epsilon=],
-        |options|' [=validated conversion options/value=]
-        |options|'s [=validated conversion options/max value=],
-        and |l1Norm|.
+    1.  Let |impressions| be the result of invoking [=common matching logic=]
+        with |options|, |topLevelSite|, |intermediarySite|, |epoch|, and |now|.
 
-    1.  If |budgetAndSafetyOk| is false, set |histogram| to the result of invoking
-        [=create an all-zero histogram=] with |options|' [=validated conversion options/histogram size=].
+    1.  If |impressions| [=set/is empty|is not empty=]:
+
+        1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
+
+        1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
+            with |key|, |impressions|,
+            |options|' [=validated conversion options/epsilon=],
+            |options|' [=validated conversion options/value=],
+            |options|'s [=validated conversion options/max value=],
+            |isSingleEpoch| and |l1Norm|.
+
+        1.  If |budgetAndSafetyOk| is true,
+            [=set/extend=] |matchedImpressions| with |impressions|.
+
+1.  If |matchedImpressions| [=set/is empty=], return the result of invoking
+[=create an all-zero histogram=] with
+|options|' [=validated conversion options/histogram size=].
+
+1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
+|options|' [=validated conversion options/histogram size=],
+|options|' [=validated conversion options/value=], and
+|options|' [=validated conversion options/credit=].
 
 1.  Return |histogram|.
 

--- a/api.bs
+++ b/api.bs
@@ -1593,17 +1593,6 @@ and [=implicit API inputs=] |implicitInputs|:
 1.  If |document| is not [=allowed to use=] the [=policy-controlled feature=] named
     "{{PermissionPolicy/save-impression}}", return [=a promise rejected with=]
     a {{"NotAllowedError"}} {{DOMException}} in |realm|.
-1.  Let |settings| be [=this=]'s [=relevant settings object=].
-1.  Collect the implicit API inputs from |settings|:
-    1.  Let |timestamp| be |settings|' [=environment settings object/current wall time=].
-    1.  The [=impression site=] |site| is set to the result of
-        [=obtain a site|obtaining a site=] from the [=top-level origin=].
-    1.  The [=intermediary site=] |intermediarySite| is set to
-        1.   a value of `undefined` if the [=origin=] is [=same site=]
-             with the [=top-level origin=],
-        1.   otherwise, the result of
-             [=obtain a site|obtaining a site=]
-             from |settings|' [=environment settings object/origin=].
 1.  Let |window| be |document|'s [=relevant global object=].
 1.  Let |activationOk| be the result of [=check attribution API activation|checking attribution API activation=]
     given |window|.

--- a/api.bs
+++ b/api.bs
@@ -1191,7 +1191,7 @@ nullable integer |l1Norm|:
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
 
 1.  Let |budgetAvailable| be the result of [=check for available privacy budget|checking for available privacy budget=]
-    with |key|, |epoch|, |deduction|, and |impressionSiteDeductions|.
+    with |key|, |deduction|, and |impressionSiteDeductions|.
 
 1.  If |budgetAvailable| is false, return false.
 
@@ -1209,6 +1209,9 @@ how locking is performed to ensure atomicity across checks and deductions, but l
 
         1.  Let |impressionQuotaKey| be an [=impression site quota key=]
             whose items are |epoch| and |impressionSite|.
+
+        1. If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
+           [=map/set=] its value to the [=impression site quota per epoch=].
 
         1.  Decrement [=impression site quota store=]\[|impressionQuotaKey|] by |siteDeduction|.
 
@@ -1236,6 +1239,8 @@ a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
 
 1.  If |deduction| is greater than |currentValue|, return false.
 
+1.  Let |epoch| be the [=epoch index=] component of |key|.
+
 1.  If the [=global privacy budget store=] does not [=map/contain=] |epoch|,
     [=map/set=] its value to the [=global budget per epoch=].
 
@@ -1247,9 +1252,8 @@ a [=map=] |impressionSiteDeductions| from [=impression sites=] to integers:
     1.  Let |impressionQuotaKey| be an [=impression site quota key=]
         whose items are |epoch| and |impressionSite|.
 
-    1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
-        compare |siteDeduction| to the value of [=impression site quota per epoch=]
-        and if it is greater, return false.
+1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|
+    and |siteDeduction| is greater than the [=impression site quota per epoch=], return false.
 
     1.  If |siteDeduction| is greater than [=impression site quota store=]\[|impressionQuotaKey|],
         return false.
@@ -1297,7 +1301,6 @@ boolean |isSingleEpoch|:
 1.  Return |impressionSiteDeductions|.
 
 </div>
-
 
 
 
@@ -1353,7 +1356,7 @@ The API can be invoked if either:
 2.  The current {{Window}} has [=transient activation=] that can be [=consume user activation|consumed=].
 
 <p class=note>This approach allows a single user action to enable multiple
-API invocations within the same page session, while still requiring
+API invocations within the same session, while still requiring
 an initial user gesture to activate the API.
 
 <p class=issue>TODO: Define how long the [=global attribution API flag=] remains true
@@ -1377,7 +1380,6 @@ throwing a {{"NotAllowedError"}} {{DOMException}} on failure:
 1.  [=Throw=] a {{"NotAllowedError"}} {{DOMException}}.
 
 </div>
-
 
 ### Epoch Start Store ### {#s-epoch-start}
 
@@ -1924,7 +1926,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
             1.  Let |key| be a [=privacy budget key=] whose items are |epoch| and |topLevelSite|.
 
             1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-                with |key|, |epoch|, |impressions|,
+                with |key|, |impressions|,
                 |options|' [=validated conversion options/epsilon=],
                 |options|' [=validated conversion options/value=],
                 |options|'s [=validated conversion options/max value=],
@@ -1939,7 +1941,6 @@ To <dfn>do attribution and fill a histogram</dfn>, given
     [=create an all-zero histogram=] with
     |options|' [=validated conversion options/histogram size=].
 
-
 1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
     |options|' [=validated conversion options/histogram size=],
     |options|' [=validated conversion options/value=], and
@@ -1953,7 +1954,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
     1.  Let |key| be a [=privacy budget key=] whose items are |currentEpoch| and |topLevelSite|.
 
     1.  Let |budgetAndSafetyOk| be the result of invoking [=deduct privacy and safety budgets=]
-        with |key|, |currentEpoch|, |impressions|,
+        with |key|, |matchedImpressions|,
         |options|' [=validated conversion options/epsilon=],
         |options|' [=validated conversion options/value=]
         |options|'s [=validated conversion options/max value=],

--- a/api.bs
+++ b/api.bs
@@ -1093,7 +1093,7 @@ that are used to manage the expenditure of [=privacy budgets=]:
     that applies across all [=sites=].
 
 *   The [=impression site quota store=] records the state
-    of per-[=impression site=] and per-[=epoch=] quota [=privacy budgets=].
+    of per-[=impression site=] and per-[=epoch=] quota for comsuming from the [=global privacy budget store=].
 
 *   The [=privacy budget store=], [=global privacy budget store=],
     and [=impression site quota store=] are updated by [=deduct privacy and safety budgets=].
@@ -1113,6 +1113,16 @@ updated to refer to the [=privacy budget store=] as well.
 
 
 ### Privacy Budget Store ### {#s-privacy-budget-store}
+A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items:
+
+<dl dfn-for="privacy budget key">
+: <dfn ignore>epoch index</dfn>
+:: An [=epoch index=]
+: <dfn ignore>site</dfn>
+:: A [=site=]
+
+</dl>
+
 
 The <dfn>privacy budget store</dfn> is a [=map=] whose keys are
 [=privacy budget keys=] and whose values are [=32-bit unsigned integers=].
@@ -1125,17 +1135,29 @@ used in differential privacy [[DP]].
 be less than or equal to the <dfn>maximum epsilon</dfn> of 4294.
 This <span class=allow-2119>should</span> be more than sufficient for implementations.
 
-A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items:
+The <dfn>global privacy budget store</dfn> is a [=map=] whose keys are
+[=epoch indices=] and whose values are [=32-bit unsigned integers=]
+in units of [=microepsilons=].
 
-<dl dfn-for="privacy budget key">
-: <dfn ignore>epoch index</dfn>
-:: An [=epoch index=]
-: <dfn ignore>site</dfn>
-:: A [=site=]
+The [=global privacy budget store=] tracks expenditure of a single [=privacy budget=]
+per [=epoch=] that applies across all [=sites=].
+This provides a [=safety limit=] against adversaries
+that can correlate activity for the same person across multiple [=sites=].
 
-</dl>
+<p class=note>Unlike the per-[=site=] [=privacy budget store=],
+the [=global privacy budget store=] is keyed only by [=epoch index=],
+not by [=site=].
 
+The <dfn>impression site quota store</dfn> is a [=map=] whose keys are
+[=privacy budget keys=] and whose values are [=32-bit unsigned integers=]
+in units of [=microepsilons=].
 
+The [=impression site quota store=] limits the amount of "stock"
+(privacy budget related to [=impressions=])
+that any single [=impression site=] can contribute in an [=epoch=].
+This prevents a single [=impression site=]
+from enabling excessive budget
+that could be maliciously triggered.
 
 <div algorithm>
 To <dfn>deduct privacy and safety budgets</dfn>
@@ -1263,34 +1285,7 @@ integer |valueDeduction|,
 </div>
 
 
-### Global Privacy Budget Store ### {#s-global-privacy-budget-store}
 
-The <dfn>global privacy budget store</dfn> is a [=map=] whose keys are
-[=epoch indices=] and whose values are [=32-bit unsigned integers=]
-in units of [=microepsilons=].
-
-The [=global privacy budget store=] tracks expenditure of a single [=privacy budget=]
-per [=epoch=] that applies across all [=sites=].
-This provides a [=safety limit=] against adversaries
-that can correlate activity for the same person across multiple [=sites=].
-
-<p class=note>Unlike the per-[=site=] [=privacy budget store=],
-the [=global privacy budget store=] is keyed only by [=epoch index=],
-not by [=site=].
-
-
-### Impression Site Quota Store ### {#s-impression-site-quota-store}
-
-The <dfn>impression site quota store</dfn> is a [=map=] whose keys are
-[=privacy budget keys=] and whose values are [=32-bit unsigned integers=]
-in units of [=microepsilons=].
-
-The [=impression site quota store=] limits the amount of "stock"
-(privacy budget related to [=impressions=])
-that any single [=impression site=] can contribute in an [=epoch=].
-This prevents a single [=impression site=]
-from enabling excessive budget
-that could be maliciously triggered.
 
 
 ### Attribution API Activation ### {#s-api-activation}
@@ -1352,28 +1347,20 @@ throwing a {{"NotAllowedError"}} {{DOMException}} on failure:
 
 
 ### Epoch Start Time ### {#s-epoch-start}
-
-For each device there is a independently random epoch cadence.  On that
-one device the per-site budget and safety limits all share this same epoch
-cadence.
-
-An [=epoch=] starts at a randomly-selected hour of the week
-for each device. This ensures that any bias in aggregates
-that arises from a [=privacy budget=] reaching zero
-is averaged across all the contributions from all [=users=].
-
-
-
-The <dfn>epoch start time</dfn> is a [=moment=]
-from the [=wall clock=].
-
 A <dfn local-lt=epoch>privacy budget epoch</dfn> (or [=epoch=])
 identifies a period of time.
 The length of an [=epoch=] is fixed at one week or 7 [=days=],
 where a <dfn>day</dfn> is defined as 86400 seconds.
 
-The exact time span for an [=epoch=] is different
-for each [=user agent=].
+The <dfn>epoch start time</dfn> is a [=moment=]
+from the [=wall clock=].  An [=epoch=] starts at a randomly-selected hour of the week
+for each [=user agent=]. This ensures that any bias in aggregates
+that arises from a [=privacy budget=] reaching zero
+is averaged across all the contributions from all [=users=].
+
+<div class=note> On each device the per-site budget and safety limits all share this same epoch
+cadence. </div>
+
 The start time
 is chosen randomly by the [=user agent=] when an epoch is first needed--
 as a side effect of invoking the [=get the current epoch=] algorithm.
@@ -1412,10 +1399,14 @@ returning an [=epoch index=]:
 
 1.  Let |period| be the [=duration=] of one [=epoch=].
 
-1.  If the [=epoch start time=] is not set,
-    set it to |t|, minus a [=duration=]
-    that is randomly selected
-    from between 0 (inclusive) and |period| (exclusive).
+1.  If the [=epoch start time=] is not set:
+
+    1.  Let |rounded| be |t|, rounded to the nearest hour
+        of the [=wall clock=].
+
+    1.  Set the [=epoch start time=] to |rounded|, minus a [=duration=]
+        that is randomly selected
+        from between 0 (inclusive) and |period| (exclusive).
 
 1.  Let |start| be the [=epoch start time=].
 

--- a/api.bs
+++ b/api.bs
@@ -1171,10 +1171,6 @@ and a [=set=] of [=safety limit epoch indices=] |deductedGlobalBudgets|:
 
 1.  Let |valueDeduction| be |valueDeductionFp| * 1000000, rounded towards positive Infinity.
 
-    <p class=note> One [=epoch=] (which is the epoch of the conversion site) can overlap with multiple [=safety limit epochs=] used by the [=global privacy budget store|global budget=]
-    and [=impression site quota store|impression site quotas=]. We will look at each impression individually and map it to the [=safety limit epoch=] it is in to deduct from the global budget
-    and impression site quota if those have not already deducted from in this call to [=measure a conversion=].
-
 <p class=issue>TODO: Additional work to specify
 how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
 
@@ -1196,17 +1192,18 @@ how locking is performed to ensure atomicity across checks and deductions, but l
     1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
         to |currentValue| − |deduction|.
 
-    1.  [=list/iterate|For each=] |impression| in |impressions|:
+    1.  Let |epoch| be the |epoch index| component of |key|.
 
-        1.  Let |impressionTime| be |impression|'s [=impression/timestamp=].
+    1.  If |deductedGlobalBudgets| does not [=map/contain=] |safetyLimitEpoch|,
+        [=set/extend=] |deductedGlobalBudgets| with |safetyLimitEpoch|
+        and decrement [=global privacy budget store=]\[|safetyLimitEpoch|] by |valueDeduction|.
+
+    1.  [=list/iterate|For each=] |impression| in |impressions|:
 
         1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-        1.  Let |safetyLimitEpoch| be the result of [=get the current safety limit epoch=]
-            with |impressionTime|.
-
         1.  Let |impressionQuotaKey| be an [=impression site quota key=]
-            whose items are |safetyLimitEpoch| and |impressionSite|.
+            whose items are the |epoch| componet of |key| and |impressionSite|.
 
         1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
             [=map/set=] its value to the [=impression site quota per epoch=].
@@ -1214,10 +1211,6 @@ how locking is performed to ensure atomicity across checks and deductions, but l
         1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|,
             [=set/extend=] |deductedImpressionQuotas| with |impressionQuotaKey|
             and decrement [=impression site quota store=]\[|impressionQuotaKey|] by |valueDeduction|.
-
-        1.  If |deductedGlobalBudgets| does not [=map/contain=] |safetyLimitEpoch|,
-            [=set/extend=] |deductedGlobalBudgets| with |safetyLimitEpoch|
-            and decrement [=global privacy budget store=]\[|safetyLimitEpoch|] by |valueDeduction|.
 
 1.  Return true.
 
@@ -1237,27 +1230,26 @@ integer |valueDeduction|,
 
 1.  If |deduction| is greater than |currentValue|, return false.
 
-1.  [=list/iterate|For each=] |impression| in |impressions|:
+1.  Let |epoch| be the |epoch index| component of |key|.
 
-    1.  Let |impressionTime| be |impression|'s [=impression/timestamp=].
+1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
+    of |epoch| from the [=global privacy budget store=], or the [=global privacy budget
+    per epoch=] if [=map/contain|no value has been set=].
+
+1. If |valueDeduction| is greater than |currentGlobalValue|, return false.
+
+1.  [=list/iterate|For each=] |impression| in |impressions|:
 
     1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-    1.  Let |safetyLimitEpoch| be the result of [=get the current safety limit epoch=]
-        with |impressionTime|.
-
-    1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
-        of |safetyLimitEpoch| from the [=global privacy budget store=], or the [=global privacy budget
-        per epoch=] if [=map/contain|no value has been set=].
-
     1.  Let |impressionQuotaKey| be an [=impression site quota key=]
-        whose items are |safetyLimitEpoch| and |impressionSite|.
+        whose items are |epoch| and |impressionSite|.
 
     1.  Let |currentImpressionQuotaValue| be set to the value of [=map/get|getting the value=]
         of |impressionQuotaKey| from the [=impression site quota store=],
         or the [=impression site quota per epoch=] if [=map/contain|no value has been set=].
 
-    1. If |valueDeduction| is greater than |currentGlobalValue| or greater than |currentImpressionQuotaValue|, return false.
+    1. If |valueDeduction| is greater than |currentImpressionQuotaValue|, return false.
 
 1.  Return true.
 
@@ -1361,11 +1353,16 @@ throwing a {{"NotAllowedError"}} {{DOMException}} on failure:
 
 ### Epoch Start Store ### {#s-epoch-start}
 
-An [=epoch=] starts at a randomly-selected time
-for each [=conversion site=].
-This ensures that any bias in aggregates
+For each device there is a independently random epoch cadence.  On that
+one device the per-site budget and safety limits all share this same epoch
+cadence.
+
+An [=epoch=] starts at a randomly-selected hour of the week
+for each device. This ensures that any bias in aggregates
 that arises from a [=privacy budget=] reaching zero
 is averaged across all the contributions from all [=users=].
+
+
 
 The <dfn>epoch start store</dfn> is a [=map=] keyed by [=site=]
 and contains values that are [=moments=]
@@ -1434,38 +1431,6 @@ returning an [=epoch index=]:
 
 </div>
 
-### Safety Limit Epoch Start ### {#s-safety-limit-epoch-start}
-A [=safety limit epoch=] starts at the same time for all devices.  This
-ensures that it does not create a device-specific value that could be learned
-through timing or other side-channel attacks.
-
-A <dfn>safety limit epoch</dfn> identifies a period of time. The length
-of a [=safety limit epoch=] is fixed at one [=day=]. The start time for a
-[=safety limit epoch=] is defined relative to the [=Unix epoch=].
-
-An <dfn local-lt="safety limit epoch indices">safety limit epoch index</dfn> is an integer
-that refers to a given [=safety limit epoch=].
-An [=safety limit epoch index=] is used to access the
-[=global privacy budget store=] and the [=impression site quota store|impression site quota stores=].
-
-[=moment|Points in time=] are translated to a [=safety limit epoch index=]
-for the corresponding [=safety limit epoch=]
-using the [=get the current safety limit epoch=] algorithm.
-
-<div algorithm>
-To <dfn>get the current safety limit epoch</dfn>
-given [=moment=] |t|,
-returning a [=safety limit epoch index=]:
-
-1.  Let |period| be the [=duration=] of one [=safety limit epoch=].
-
-1.  Let |start| be the [=Unix epoch=].
-
-1.  Let |elapsed| be (|t| − |start|) / |period|.
-
-1.  Return |elapsed| as an integer, rounded towards negative Infinity.
-
-</div>
 
 ### Last Browsing History Clear Time ### {#last-clear}
 
@@ -1943,15 +1908,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
 1.  Let |deductedGlobalBudgets| be a new [=set=].
 
-<p class=note> The |deductedImpressionQuotas| and |deductedGlobalBudgets| sets are initialized outside the
-loop over epochs so that [=safety limit epochs=] which overlap two per-site [=epochs=] will not be have
-their safety limits deducted from more than once.
-
 1.  For each |epoch| from |currentEpoch| to |startEpoch|, inclusive:
-
-    <p class=note> Epochs are processed sequentially starting from the most recent epoch
-    and going back in time as safety limit deductions can depleate from same safety limits as
-    the next epoch will need to check.
 
     1.  Let |impressions| be the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |epoch|, and |now|.

--- a/api.bs
+++ b/api.bs
@@ -1081,9 +1081,8 @@ that are used to manage the expenditure of [=privacy budgets=]:
 *   The [=privacy budget store=] records the state
     of the per-[=site=] and per-[=epoch=] [=privacy budgets=].
 
-*   The [=epoch start store=] records when each [=epoch=] starts
-    for [=conversion sites=].
-    This store is initialized as a side effect
+*   The [=epoch start time=] records when the first [=epoch=] starts.
+    This value is initialized as a side effect
     of invoking <a method for=Attribution>measureConversion()</a>.
 
 *   A singleton [=last browsing history clear=] value
@@ -1351,7 +1350,7 @@ throwing a {{"NotAllowedError"}} {{DOMException}} on failure:
 </div>
 
 
-### Epoch Start Store ### {#s-epoch-start}
+### Epoch Start Time ### {#s-epoch-start}
 
 For each device there is a independently random epoch cadence.  On that
 one device the per-site budget and safety limits all share this same epoch
@@ -1364,8 +1363,7 @@ is averaged across all the contributions from all [=users=].
 
 
 
-The <dfn>epoch start store</dfn> is a [=map=] keyed by [=site=]
-and contains values that are [=moments=]
+The <dfn>epoch start time</dfn> is a [=moment=]
 from the [=wall clock=].
 
 A <dfn local-lt=epoch>privacy budget epoch</dfn> (or [=epoch=])
@@ -1374,19 +1372,16 @@ The length of an [=epoch=] is fixed at one week or 7 [=days=],
 where a <dfn>day</dfn> is defined as 86400 seconds.
 
 The exact time span for an [=epoch=] is different
-for each combination of [=user agent=] and [=site=].
-The start time for a given pair of [=user agent=] and [=site=]
+for each [=user agent=].
+The start time
 is chosen randomly by the [=user agent=] when an epoch is first needed--
 as a side effect of invoking the [=get the current epoch=] algorithm.
-The [=epochs=] for a given [=site=] will change
-if the [=user agent=] clears browsing history;
-see [[#clear-browsing-history]].
 
 An <dfn local-lt="epoch indices">epoch index</dfn> is an integer
 that refers to a given [=epoch=].
 An [=epoch index=] is used to access
 the [=impression store|impression=]
-and [=epoch start store|epoch start=] stores.
+and [=epoch start time=].
 
 <div class=note>
 In the same way that a [=moment=] is an abstract concept
@@ -1397,7 +1392,7 @@ relative to another [=moment=],
 [=Epoch indices=] are stored as integers
 relative to a set reference point.
 The [=epoch indices=] in this specification
-use the values from the [=epoch start store=]
+use the [=epoch start time=]
 as a reference point.
 A [=user agent=] could choose to use a different [=moment=]
 to indicate a "zero" or reference [=epoch=].
@@ -1411,19 +1406,17 @@ using the [=get the current epoch=] algorithm.
 
 <div algorithm>
 To <dfn>get the current epoch</dfn>
-given a [=site=] |site|,
-and [=moment=] |t|,
+given a [=moment=] |t|,
 returning an [=epoch index=]:
 
 1.  Let |period| be the [=duration=] of one [=epoch=].
 
-1.  If the [=epoch start store=] does not [=map/contain=] |site|, [=map/set=]
-    its value to |t|, minus a [=duration=]
+1.  If the [=epoch start time=] is not set,
+    set it to |t|, minus a [=duration=]
     that is randomly selected
     from between 0 (inclusive) and |period| (exclusive).
 
-1.  Let |start| be the result of [=map/get|getting the value=] of |site|
-    from the [=epoch start store=].
+1.  Let |start| be the [=epoch start time=].
 
 1.  Let |elapsed| be (|t| − |start|) / |period|.
 
@@ -1451,7 +1444,7 @@ all of the following are true:
     that have other uncleared interactions.
 *   All cleared interactions occurring during [=epochs=]
     where other interactions with the same [=site=] were retained.
-*   All affected [=sites=] have a value in the [=epoch start store=].
+*   The [=epoch start time=] is set.
 
 If all three conditions are true,
 the [=last browsing history clear=] does not need to be updated.
@@ -1478,7 +1471,7 @@ given [=site=] |site| and [=moment=] |now|,
 returning an [=epoch index=]:
 
 1.  Let |earliestEpochIndex| be the result of [=get the current epoch=]
-    with |site| and |now| − the [=maximum lookback=] [=days=].
+    with |now| − the [=maximum lookback=] [=days=].
 
     <p class=note>
     This ensures that all possible [=impressions=] can be queried.
@@ -1489,12 +1482,12 @@ returning an [=epoch index=]:
     perform the following steps:
 
     1.  Let |clearEpoch| be the result of [=get the current epoch=]
-        with |site| and the value of [=last browsing history clear=].
+        with the value of [=last browsing history clear=].
 
         <p class=note>
         This use of [=get the current epoch=]
         can return a negative value.
-        This is because the value in [=epoch start store=]
+        This is because the [=epoch start time=]
         is likely to be set to a time after history was last cleared.
 
     1.  Set |clearEpoch| to |clearEpoch| + 2.
@@ -1502,9 +1495,7 @@ returning an [=epoch index=]:
         <p class=note>
         Adding <em>two</em> is necessary so that the [=epoch=]
         does not overlap with an [=epoch=]
-        before browsing history--
-        and the [=epoch start store=]--
-        was cleared.
+        before browsing history was cleared.
 
     1.  If |clearEpoch| is greater than |startEpoch|,
         return |clearEpoch|.
@@ -1531,7 +1522,7 @@ and a [=moment=] |now|:
 
         1.  Let |currentEpoch| be the result of
             invoking [=get the current epoch=]
-            given |site| and |now|.
+            given |now|.
 
         1.  [=set/iterate|For each=] |epoch| in [=the inclusive range=]
             from |startingEpoch| to |currentEpoch|:
@@ -1549,8 +1540,6 @@ and a [=moment=] |now|:
 
     1.  [=map/clear|Clear=] the [=privacy budget store=].
 
-    1.  [=map/clear|Clear=] the [=epoch start store=].
-
     <p class=issue>TODO (issue https://github.com/w3c/attribution/issues/367): Define how to clear [=safety limits=] stores:
     [=global privacy budget store=] and [=impression site quota store=].
 
@@ -1563,10 +1552,6 @@ and a [=moment=] |now|:
     1.  [=set/iterate|For each=] |key| in the [=map/getting the keys|keys=] of the [=privacy budget store=],
         if |sites| [=set/contains=] the [=site=] component of |key|,
         [=map/remove=] [=privacy budget store=]\[|key|].
-
-    1.  [=set/iterate|For each=] |key| in the [=map/getting the keys|keys=] of the [=epoch start store=],
-        if |sites| [=set/contains=] |key|,
-        [=map/remove=] [=epoch start store=]\[|key|].
 
 1.  Set the [=last browsing history clear=] to |now|.
 
@@ -1877,13 +1862,13 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
 
 1.  Let |currentEpoch| be the result of [=get the current epoch=]
-    with |topLevelSite| and |now|.
+    with |now|.
 
 1.  Let |startEpoch| be the result of [=get the starting epoch for attribution=]
     with |topLevelSite| and |now|.
 
 1.  Let |earliestEpoch| be the result of calling [=get the current epoch=],
-    passing |topLevelSite| and (|now| − |options|' [=validated conversion options/lookback=]).
+    passing (|now| − |options|' [=validated conversion options/lookback=]).
 
 1.  Let |isSingleEpoch| be true if |currentEpoch| is equal to |earliestEpoch|, false otherwise.
 
@@ -1961,7 +1946,7 @@ To perform <dfn>common matching logic</dfn>, given
 1.  [=set/iterate|For each=] |impression| in the [=impression store=]:
 
     1.  Let |impressionEpoch| be the result of calling [=get the current epoch=],
-        passing |topLevelSite| and |impression|'s [=impression/timestamp=].
+        passing |impression|'s [=impression/timestamp=].
 
     1.  If |impressionEpoch| is not equal to |epoch|, [=iteration/continue=].
 
@@ -3465,7 +3450,7 @@ Sites would then be able to gain more information
 from attribution.
 
 A [=user agent=] may clear data
-from the [=privacy budget store=] and [=epoch start store=]
+from the [=privacy budget store=] and [=epoch start time=]
 when the API is [[#opt-out|disabled]].
 In that case, if the API is re-enabled,
 there is no way to determine what budget was expended
@@ -3493,7 +3478,7 @@ When clearing site data at the request of a [=site=],
 through the use of the [:Clear-Site-Data:] header,
 a [=user agent=] only [=clear impressions for a site|removes impressions=],
 without altering either the [=privacy budget store=]
-or the [=epoch start store=] for affected [=sites=].
+or the [=epoch start time=].
 
 
 ### Clearing Browsing History ### {#clear-browsing-history}
@@ -3515,8 +3500,7 @@ and the time that the operation was initiated.
 When clearing browsing history,
 [=user agents=] need to
 remove all per-[=site=] [=privacy budget=] information
-(that is, remove entries from both the [=privacy budget store=]
-and the [=epoch start store=]).
+(that is, remove entries from the [=privacy budget store=]).
 [=User agents=] also need to ensure that
 any subsequent [=privacy budget=] expenditure
 cannot cause privacy loss in excess of configured limits
@@ -3533,12 +3517,10 @@ than it could without the clearing of state.
 <p class=note>
 This disables the API for up to <em>two</em> [=epochs=]
 for affected [=sites=].
-Because the [=epoch start store=] is cleared,
-the start of any newly-defined [=epoch=] for that [=site=]
-becomes unknown.
-Any new [=epoch=] will [start at a fresh randomly-selected time](#s-epoch-start),
-which cannot overlap with any [=epoch=] that might have been defined
-before history was cleared.
+Because the [=epoch start time=] is not cleared,
+the [=epoch=] timeline remains continuous.
+However, a new [=epoch=] might overlap with an [=epoch=]
+that existed before history was cleared.
 
 A [=user agent=] remembers when history was last cleared
 in the [=last browsing history clear=] value.

--- a/api.bs
+++ b/api.bs
@@ -1197,7 +1197,7 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
     with |key|, |l1NormDeduction|, |valueDeduction|,
-    |impressions|, and |isSingleEpoch|,
+    |impressions|, and |isSingleEpoch|
     is false, return false.
 
 1.  All budget checks passed, so perform the deductions:
@@ -1215,9 +1215,9 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
     1.  Let |epoch| be the [=epoch index=] component of |key|.
 
-    1.  If |deductedGlobalBudgets| does not [=map/contain=] |safetyLimitEpoch|,
-        [=set/append=] |deductedGlobalBudgets| with |safetyLimitEpoch|
-        and decrement [=global privacy budget store=]\[|safetyLimitEpoch|] by |valueDeduction|.
+    1.  If |deductedGlobalBudgets| does not [=set/contain=] |epoch|,
+        [=set/append=] |deductedGlobalBudgets| with |epoch|
+        and decrement [=global privacy budget store=]\[|epoch|] by |valueDeduction|.
 
     1.  [=list/iterate|For each=] |impression| in |impressions|:
 
@@ -1229,11 +1229,11 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
         1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
             [=map/set=] its value to the [=impression site quota per epoch=].
 
-        1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|,
-            [=set/append=] |deductedImpressionQuotas| with |impressionQuotaKey|.
+            <p class=note> The below line checks that we do not deduct more than once from the same impression
+            quota when there are multiple impressions for the site
 
-                <p class=note> Do not deduct more than once from the same impression
-                quota when there are multiple impressions for the site
+        1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|,
+            [=set/append=] |deductedImpressionQuotas| with |impressionQuotaKey| and do the following:
 
             1.  Let |currentImpressionQuotaValue| be the result of [=map/get|getting the value=] of |impressionQuotaKey|
                 in the [=impression site quota per epoch=].
@@ -1864,7 +1864,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
 1.  Let |isSingleEpoch| be true if |currentEpoch| is equal to |earliestEpoch|, false otherwise.
 
-1.  Let |l1Norm| be initialized to 0.
+1.  Let |l1Norm| be 0.
 
 1.  If |isSingleEpoch| is true:
     1.  Set |matchedImpressions| to the result of invoking [=common matching logic=]
@@ -1891,6 +1891,8 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
     1.  Let |impressions| be the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |epoch|, and |now|.
+
+        <p class=note>| In the single-epoch case, this is recomputing |matchedImpressions|.
 
     1.  If |impressions| [=set/is empty|is not empty=]:
 

--- a/api.bs
+++ b/api.bs
@@ -1166,15 +1166,15 @@ and a [=set=] of [=safety limit epoch indices=] |deductedGlobalBudgets|:
     proportional to |maxValue| / |epsilon|
     is added to the aggregated histogram.
 
-1.  Let |l1Normdeduction| be |l1NormDeductionFp| * 1000000, rounded towards positive Infinity.
+1.  Let |l1NormDeduction| be |l1NormDeductionFp| * 1000000, rounded towards positive Infinity.
 
 1.  Let |valueDeduction| be |valueDeductionFp| * 1000000, rounded towards positive Infinity.
 
-<p class=issue>TODO: Additional work to specify
-how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
+    <p class=issue>TODO: Additional work to specify
+    how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
 
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
-    with |key|, |l1Normdeduction|, |valueDeduction|,
+    with |key|, |l1NormDeduction|, |valueDeduction|,
     |impressions|, and |isSingleEpoch|,
     is false, return false.
 
@@ -1186,7 +1186,7 @@ how locking is performed to ensure atomicity across checks and deductions, but l
     1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
         in the [=privacy budget store=].
 
-    1.  If |isSingleEpoch| let |deduction| be |l1Normdeduction| else let |deduction| be |valueDeduction|
+    1.  If |isSingleEpoch| let |deduction| be |l1NormDeduction| else let |deduction| be |valueDeduction|.
 
     1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
         to |currentValue| − |deduction|.
@@ -1194,7 +1194,7 @@ how locking is performed to ensure atomicity across checks and deductions, but l
     1.  Let |epoch| be the |epoch index| component of |key|.
 
     1.  If |deductedGlobalBudgets| does not [=map/contain=] |safetyLimitEpoch|,
-        [=set/extend=] |deductedGlobalBudgets| with |safetyLimitEpoch|
+        [=set/append=] |deductedGlobalBudgets| with |safetyLimitEpoch|
         and decrement [=global privacy budget store=]\[|safetyLimitEpoch|] by |valueDeduction|.
 
     1.  [=list/iterate|For each=] |impression| in |impressions|:
@@ -1208,7 +1208,7 @@ how locking is performed to ensure atomicity across checks and deductions, but l
             [=map/set=] its value to the [=impression site quota per epoch=].
 
         1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|,
-            [=set/extend=] |deductedImpressionQuotas| with |impressionQuotaKey|
+            [=set/append=] |deductedImpressionQuotas| with |impressionQuotaKey|
             and decrement [=impression site quota store=]\[|impressionQuotaKey|] by |valueDeduction|.
 
 1.  Return true.
@@ -1217,7 +1217,7 @@ how locking is performed to ensure atomicity across checks and deductions, but l
 
 <div algorithm>
 To <dfn>check for available privacy budget</dfn>
-given a [=privacy budget key=] |key|, integer |l1Normdeduction|,
+given a [=privacy budget key=] |key|, integer |l1NormDeduction|,
 integer |valueDeduction|,
 [=set=] of [=impressions=] |impressions| and boolean |isSingleEpoch|:
 
@@ -1225,13 +1225,13 @@ integer |valueDeduction|,
     from [=privacy budget store=], or the [=per-site privacy budget=]
     if [=map/contain|no value has been set=].
 
-1.  If |isSingleEpoch| let |deduction| be |l1Normdeduction| else let |deduction| be |valueDeduction|
+1.  If |isSingleEpoch| let |deduction| be |l1NormDeduction| else let |deduction| be |valueDeduction|.
 
 1.  If |deduction| is greater than |currentValue|, return false.
 
 1.  Let |epoch| be the |epoch index| component of |key|.
 
-1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
+1.  Let |currentGlobalValue| be the value of [=map/get|getting the value=]
     of |epoch| from the [=global privacy budget store=], or the [=global privacy budget
     per epoch=] if [=map/contain|no value has been set=].
 
@@ -1244,7 +1244,7 @@ integer |valueDeduction|,
     1.  Let |impressionQuotaKey| be an [=impression site quota key=]
         whose items are |epoch| and |impressionSite|.
 
-    1.  Let |currentImpressionQuotaValue| be set to the value of [=map/get|getting the value=]
+    1.  Let |currentImpressionQuotaValue| be the value of [=map/get|getting the value=]
         of |impressionQuotaKey| from the [=impression site quota store=],
         or the [=impression site quota per epoch=] if [=map/contain|no value has been set=].
 
@@ -1872,6 +1872,8 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
 1.  Let |isSingleEpoch| be true if |currentEpoch| is equal to |earliestEpoch|, false otherwise.
 
+1.  Let |l1Norm| be initialized to 0.
+
 1.  If |isSingleEpoch| is true:
     1.  Set |matchedImpressions| to the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |currentEpoch|, and |now|.
@@ -1880,12 +1882,12 @@ To <dfn>do attribution and fill a histogram</dfn>, given
           [=create an all-zero histogram=] with
           |options|' [=validated conversion options/histogram size=].
 
-    1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
+    1.  Let |histogram| be the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
         |options|' [=validated conversion options/histogram size=],
         |options|' [=validated conversion options/value=], and
         |options|' [=validated conversion options/credit=].
 
-    1.  Let |l1Norm| be the sum of the [=list/items=] in |histogram|.
+    1.  Set |l1Norm| be the sum of the [=list/items=] in |histogram|.
 
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
 
@@ -1907,7 +1909,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
             |options|' [=validated conversion options/epsilon=],
             |options|' [=validated conversion options/value=],
             |options|'s [=validated conversion options/max value=],
-            |isSingleEpoch|, |l1Norm|, |deductedImpressionQuotas| and |deductedGlobalBudgets|.
+            |isSingleEpoch|, |l1Norm|, |deductedImpressionQuotas|, and |deductedGlobalBudgets|.
 
         1.  If |budgetAndSafetyOk| is true,
             [=set/extend=] |matchedImpressions| with |impressions|.
@@ -1916,7 +1918,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
     [=create an all-zero histogram=] with
     |options|' [=validated conversion options/histogram size=].
 
-1.  Set |histogram| to the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
+1.  Let |histogram| be the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
     |options|' [=validated conversion options/histogram size=],
     |options|' [=validated conversion options/value=], and
     |options|' [=validated conversion options/credit=].

--- a/api.bs
+++ b/api.bs
@@ -1232,8 +1232,9 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
             <p class=note> The below line checks that we do not deduct more than once from the same impression
             quota when there are multiple impressions for the site
 
-        1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|,
-            [=set/append=] |deductedImpressionQuotas| with |impressionQuotaKey| and do the following:
+        1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|:
+
+            1.  [=set/append=] |deductedImpressionQuotas| with |impressionQuotaKey|.
 
             1.  Let |currentImpressionQuotaValue| be the result of [=map/get|getting the value=] of |impressionQuotaKey|
                 in the [=impression site quota per epoch=].

--- a/api.bs
+++ b/api.bs
@@ -1145,7 +1145,7 @@ given a [=privacy budget key=] |key|,
 integer |value|,
 integer |maxValue|,
 boolean |isSingleEpoch|, integer |l1Norm|, [=set=] of [=impression site quota keys=] |deductedImpressionQuotas|
-and a [=set=] of [=safety limit epoch indices=] |deductedGlobalBudgets|:
+and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
 1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
 
@@ -1191,7 +1191,7 @@ and a [=set=] of [=safety limit epoch indices=] |deductedGlobalBudgets|:
     1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
         to |currentValue| − |deduction|.
 
-    1.  Let |epoch| be the |epoch index| component of |key|.
+    1.  Let |epoch| be the [=epoch index=] component of |key|.
 
     1.  If |deductedGlobalBudgets| does not [=map/contain=] |safetyLimitEpoch|,
         [=set/append=] |deductedGlobalBudgets| with |safetyLimitEpoch|
@@ -1202,7 +1202,7 @@ and a [=set=] of [=safety limit epoch indices=] |deductedGlobalBudgets|:
         1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
         1.  Let |impressionQuotaKey| be an [=impression site quota key=]
-            whose items are the |epoch| componet of |key| and |impressionSite|.
+            whose items are |epoch| and |impressionSite|.
 
         1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
             [=map/set=] its value to the [=impression site quota per epoch=].
@@ -1467,7 +1467,7 @@ is exposed.
 
 <div algorithm="get the starting epoch for attribution">
 To <dfn>get the starting epoch for attribution</dfn>
-given [=site=] |site| and [=moment=] |now|,
+given [=moment=] |now|,
 returning an [=epoch index=]:
 
 1.  Let |earliestEpochIndex| be the result of [=get the current epoch=]
@@ -1518,7 +1518,7 @@ and a [=moment=] |now|:
 
         1.  Let |startingEpoch| be the result of
             invoking [=get the starting epoch for attribution=]
-            given |site| and |now|.
+            given |now|.
 
         1.  Let |currentEpoch| be the result of
             invoking [=get the current epoch=]
@@ -1865,7 +1865,7 @@ To <dfn>do attribution and fill a histogram</dfn>, given
     with |now|.
 
 1.  Let |startEpoch| be the result of [=get the starting epoch for attribution=]
-    with |topLevelSite| and |now|.
+    with |now|.
 
 1.  Let |earliestEpoch| be the result of calling [=get the current epoch=],
     passing (|now| − |options|' [=validated conversion options/lookback=]).
@@ -3173,7 +3173,7 @@ of harmful information flow through the impression store:
 
 The Attribution APIs must be implemented carefully
 to maintain the required security and privacy properties.
-A site calling the APIs must not be able to learn:
+A site calling the APIs cannot learn:
 
 *   Whether the Attribution APIs are [[#opt-out|enabled]].
 *   Whether an attribution occurred.
@@ -3342,7 +3342,7 @@ a mechanism for the user to disable the Attribution API.
 To minimize the risk of [=fingerprinting=],
 and to prevent discrimination
 against users who choose to disable the Attribution API,
-sites must not be able to detect that the API is disabled.
+sites cannot detect that the API is disabled.
 Specifically, all calls to the Attribution API
 that are otherwise valid
 must complete successfully, even when the API is disabled.

--- a/api.bs
+++ b/api.bs
@@ -1178,7 +1178,7 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
     |impressions|, and |isSingleEpoch|,
     is false, return false.
 
-1.  All budget checks passed, so perform the deductions atomically:
+1.  All budget checks passed, so perform the deductions:
 
     1.  If the [=privacy budget store=] does not [=map/contain=] |key|,
         [=map/set=] its value to the [=per-site privacy budget=].
@@ -1208,8 +1208,17 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
             [=map/set=] its value to the [=impression site quota per epoch=].
 
         1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|,
-            [=set/append=] |deductedImpressionQuotas| with |impressionQuotaKey|
-            and decrement [=impression site quota store=]\[|impressionQuotaKey|] by |valueDeduction|.
+            [=set/append=] |deductedImpressionQuotas| with |impressionQuotaKey|.
+
+                <p class=note> Do not deduct more than once from the same impression
+                quota when there are multiple impressions for the site
+
+            1.  Let |currentImpressionQuotaValue| be the result of [=map/get|getting the value=] of |impressionQuotaKey|
+                in the [=impression site quota per epoch=].
+
+            1.  [=map/set|Set=] the value of |impressionQuotaKey| in the [=impression site quota per epoch=]
+                to |currentImpressionQuotaValue| − |valueDeduction|.
+
 
 1.  Return true.
 
@@ -1221,19 +1230,18 @@ given a [=privacy budget key=] |key|, integer |l1NormDeduction|,
 integer |valueDeduction|,
 [=set=] of [=impressions=] |impressions| and boolean |isSingleEpoch|:
 
-1.  Let |currentValue| be set to the value of [=map/get|getting the value=] of |key|
-    from [=privacy budget store=], or the [=per-site privacy budget=]
-    if [=map/contain|no value has been set=].
-
 1.  If |isSingleEpoch| let |deduction| be |l1NormDeduction| else let |deduction| be |valueDeduction|.
+
+1.  Let |currentValue| be set to the value of [=map/get|getting the value=] of |key|
+    from [=privacy budget store=], with a default of the [=per-site privacy budget=].
 
 1.  If |deduction| is greater than |currentValue|, return false.
 
 1.  Let |epoch| be the |epoch index| component of |key|.
 
-1.  Let |currentGlobalValue| be the value of [=map/get|getting the value=]
-    of |epoch| from the [=global privacy budget store=], or the [=global privacy budget
-    per epoch=] if [=map/contain|no value has been set=].
+1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
+    of |epoch| from the [=global privacy budget store=], with a default of the [=global privacy budget
+    per epoch=].
 
 1. If |valueDeduction| is greater than |currentGlobalValue|, return false.
 
@@ -1244,9 +1252,9 @@ integer |valueDeduction|,
     1.  Let |impressionQuotaKey| be an [=impression site quota key=]
         whose items are |epoch| and |impressionSite|.
 
-    1.  Let |currentImpressionQuotaValue| be the value of [=map/get|getting the value=]
-        of |impressionQuotaKey| from the [=impression site quota store=],
-        or the [=impression site quota per epoch=] if [=map/contain|no value has been set=].
+    1.  Let |currentImpressionQuotaValue| be set to the value of [=map/get|getting the value=]
+        of |impressionQuotaKey| from the [=impression site quota store=], with a default of
+        the [=impression site quota per epoch=].
 
     1. If |valueDeduction| is greater than |currentImpressionQuotaValue|, return false.
 
@@ -1261,7 +1269,7 @@ The <dfn>global privacy budget store</dfn> is a [=map=] whose keys are
 [=epoch indices=] and whose values are [=32-bit unsigned integers=]
 in units of [=microepsilons=].
 
-The [=global privacy budget store=] enforces a single [=privacy budget=]
+The [=global privacy budget store=] tracks expenditure of a single [=privacy budget=]
 per [=epoch=] that applies across all [=sites=].
 This provides a [=safety limit=] against adversaries
 that can correlate activity for the same person across multiple [=sites=].
@@ -1274,18 +1282,8 @@ not by [=site=].
 ### Impression Site Quota Store ### {#s-impression-site-quota-store}
 
 The <dfn>impression site quota store</dfn> is a [=map=] whose keys are
-[=impression site quota keys=] and whose values are [=32-bit unsigned integers=]
+[=privacy budget keys=] and whose values are [=32-bit unsigned integers=]
 in units of [=microepsilons=].
-
-An <dfn>impression site quota key</dfn> is a [=tuple=] consisting of the following items:
-
-<dl dfn-for="impression site quota key">
-: <dfn ignore>epoch index</dfn>
-:: An [=epoch index=]
-: <dfn ignore>impression site</dfn>
-:: An [=impression site=]
-
-</dl>
 
 The [=impression site quota store=] limits the amount of "stock"
 (privacy budget related to [=impressions=])
@@ -1297,7 +1295,10 @@ that could be maliciously triggered.
 
 ### Attribution API Activation ### {#s-api-activation}
 
-The Attribution API is a [=transient activation-consuming API=].
+<p class=issue>The following text is not completely accurate.
+See https://github.com/w3c/attribution/issues/378 for details.
+
+The Attribution API is like a [=transient activation-consuming API=].
 The web platform uses <a href="https://html.spec.whatwg.org/#tracking-user-activation">transient activation</a> to limit the amount of time that a
 user activation remains available for calling certain user activation-gated APIs.
 The Attribution API can be activated by transient activation,
@@ -1490,7 +1491,7 @@ returning an [=epoch index=]:
         This is because the [=epoch start time=]
         is likely to be set to a time after history was last cleared.
 
-    1.  Set |clearEpoch| to |clearEpoch| + 2.
+    1.  Set |clearEpoch| to |clearEpoch| + 1.
 
         <p class=note>
         Adding <em>two</em> is necessary so that the [=epoch=]
@@ -2128,15 +2129,20 @@ for the following:
 *   The <dfn>global privacy budget per epoch</dfn> (&epsilon;<sub>global</sub>) which is
     the maximum privacy budget available across all [=sites=] per [=epoch=],
     specified in [=microepsilons=].
-    Implementations [=must=] set this value as a multiple of
+    Implementations [=should=] set this value as a multiple of
     the per-[=site=] [=privacy budget=] per [=epoch=].
 
 *   The <dfn>impression site quota per epoch</dfn> (&epsilon;<sub>imp-quota</sub>) which is
     the maximum privacy budget that a single [=impression site=]
     can enable to be consumed from the [=global privacy budget store|global privacy budget=] per [=epoch=],
     specified in [=microepsilons=].
-    Implementations [=must=] set this value as a multiple of
+    Implementations [=should=] set this value as a multiple of
     the per-[=site=] [=privacy budget=] per [=epoch=].
+
+<p class=note> Configuring [=safety limits=] as multiples of the per-[=site=] budget determines
+how the API can be used by multiple sites. It is encouraged to consider the expectation of the number
+of sites that might use their budget, maybe adjusted downward for the number of sites that do
+not fully use the budget provided to them.
 
 <p class=note>Setting [=safety limits=] as multiples of the per-[=site=] budget
 ensures that exploiting shared limits requires coordination by many sites,
@@ -3509,20 +3515,18 @@ cannot cause privacy loss in excess of configured limits
 as a result of losing that information.
 
 This can be achieved by disabling attribution
-for a period between one and two [=epochs=]
-from the point that browsing history is discarded.
+for the [=epoch=]
+in which browsing history was discarded.
 Otherwise, a [=site=] that expends its budget
 immediately prior to the clearing of history
 would be able to learn more through the API
 than it could without the clearing of state.
 
 <p class=note>
-This disables the API for up to <em>two</em> [=epochs=]
+This disables the API for the remainder of the [=epoch=]
 for affected [=sites=].
 Because the [=epoch start time=] is not cleared,
 the [=epoch=] timeline remains continuous.
-However, a new [=epoch=] might overlap with an [=epoch=]
-that existed before history was cleared.
 
 A [=user agent=] remembers when history was last cleared
 in the [=last browsing history clear=] value.

--- a/api.bs
+++ b/api.bs
@@ -1201,7 +1201,7 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
         1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-        1.  Let |impressionQuotaKey| be an [=impression site quota key=]
+        1.  Let |impressionQuotaKey| be an [=privacy budget key=]
             whose items are |epoch| and |impressionSite|.
 
         1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
@@ -1249,7 +1249,7 @@ integer |valueDeduction|,
 
     1.  Let |impressionSite| be |impression|'s [=impression/impression site=].
 
-    1.  Let |impressionQuotaKey| be an [=impression site quota key=]
+    1.  Let |impressionQuotaKey| be an [=privacy budget key=]
         whose items are |epoch| and |impressionSite|.
 
     1.  Let |currentImpressionQuotaValue| be set to the value of [=map/get|getting the value=]
@@ -3351,7 +3351,7 @@ By design, whether a user has opted out is not detectable by websites.
 To minimize the risk of [=fingerprinting=],
 and to prevent discrimination
 against users who choose to disable the Attribution API,
-sites [=must not=] be able to detect that the API is disabled.
+sites <span class=allow-2119>must not</span> be able to detect that the API is disabled.
 Specifically, all calls to the Attribution API
 that are otherwise valid
 complete successfully, even when the API is disabled.

--- a/api.bs
+++ b/api.bs
@@ -1230,11 +1230,11 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
             [=map/set=] its value to the [=impression site quota per epoch=].
 
             <p class=note> The below line checks that we do not deduct more than once from the same impression
-            quota when there are multiple impressions for the site
+            quota when there are multiple impressions for the site.
 
         1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|:
 
-            1.  [=set/append=] |deductedImpressionQuotas| with |impressionQuotaKey|.
+            1.  [=set/Append=] |deductedImpressionQuotas| with |impressionQuotaKey|.
 
             1.  Let |currentImpressionQuotaValue| be the result of [=map/get|getting the value=] of |impressionQuotaKey|
                 in the [=impression site quota per epoch=].

--- a/api.bs
+++ b/api.bs
@@ -1113,6 +1113,7 @@ updated to refer to the [=privacy budget store=] as well.
 
 
 ### Privacy Budget Store ### {#s-privacy-budget-store}
+
 A <dfn>privacy budget key</dfn> is a [=tuple=] consisting of the following items:
 
 <dl dfn-for="privacy budget key">
@@ -1140,7 +1141,8 @@ The <dfn>global privacy budget store</dfn> is a [=map=] whose keys are
 in units of [=microepsilons=].
 
 The [=global privacy budget store=] tracks expenditure of a single [=privacy budget=]
-per [=epoch=] that applies across all [=sites=].
+that applies across all [=sites=]
+and refreshes each [=epoch=].
 This provides a [=safety limit=] against adversaries
 that can correlate activity for the same person across multiple [=sites=].
 
@@ -1156,7 +1158,8 @@ The [=impression site quota store=] limits the amount of "stock"
 (privacy budget related to [=impressions=])
 that any single [=impression site=] can contribute in an [=epoch=].
 This prevents a single [=impression site=]
-from enabling excessive budget
+from consuming excessive amounts
+from the [=global privacy budget store|global limit=]
 that could be maliciously triggered.
 
 <div algorithm>
@@ -1166,7 +1169,9 @@ given a [=privacy budget key=] |key|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|,
-boolean |isSingleEpoch|, integer |l1Norm|, [=set=] of [=privacy budget keys=] |deductedImpressionQuotas|
+boolean |isSingleEpoch|,
+integer |l1Norm|,
+[=set=] of [=privacy budget keys=] |deductedImpressionQuotas|
 and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
 1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
@@ -1192,9 +1197,6 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
 1.  Let |valueDeduction| be |valueDeductionFp| * 1000000, rounded towards positive Infinity.
 
-    <p class=issue>TODO: Additional work to specify
-    how locking is performed to ensure atomicity across checks and deductions, but lock should start about here.
-
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
     with |key|, |l1NormDeduction|, |valueDeduction|,
     |impressions|, and |isSingleEpoch|
@@ -1202,13 +1204,12 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
 1.  All budget checks passed, so perform the deductions:
 
-    1.  If the [=privacy budget store=] does not [=map/contain=] |key|,
-        [=map/set=] its value to the [=per-site privacy budget=].
+    1.  If |isSingleEpoch| let |deduction| be |l1NormDeduction| else let |deduction| be |valueDeduction|.
+
 
     1.  Let |currentValue| be the result of [=map/get|getting the value=] of |key|
-        in the [=privacy budget store=].
-
-    1.  If |isSingleEpoch| let |deduction| be |l1NormDeduction| else let |deduction| be |valueDeduction|.
+        in the [=privacy budget store=]
+        with a default of the [=per-site privacy budget=]..
 
     1.  [=map/set|Set=] the value of |key| in the [=privacy budget store=]
         to |currentValue| − |deduction|.
@@ -1226,22 +1227,20 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
         1.  Let |impressionQuotaKey| be an [=privacy budget key=]
             whose items are |epoch| and |impressionSite|.
 
-        1.  If the [=impression site quota store=] does not [=map/contain=] |impressionQuotaKey|,
-            [=map/set=] its value to the [=impression site quota per epoch=].
-
-            <p class=note> The below line checks that we do not deduct more than once from the same impression
-            quota when there are multiple impressions for the site.
+            <p class=note>The below ensures that we do not deduct budget
+            more than once from the same impression site quota
+            when there are multiple impressions for the site.
 
         1.  If |deductedImpressionQuotas| does not [=map/contain=] |impressionQuotaKey|:
 
             1.  [=set/Append=] |deductedImpressionQuotas| with |impressionQuotaKey|.
 
             1.  Let |currentImpressionQuotaValue| be the result of [=map/get|getting the value=] of |impressionQuotaKey|
-                in the [=impression site quota per epoch=].
+                in the [=impression site quota per epoch=]
+                with a default of the [=impression site quota per epoch=].
 
-            1.  [=map/set|Set=] the value of |impressionQuotaKey| in the [=impression site quota per epoch=]
+            1.  [=map/set|Set=] the value of [=impression site quota per epoch=]\[|impressionQuotaKey|\]
                 to |currentImpressionQuotaValue| − |valueDeduction|.
-
 
 1.  Return true.
 
@@ -1256,14 +1255,16 @@ integer |valueDeduction|,
 1.  If |isSingleEpoch| let |deduction| be |l1NormDeduction| else let |deduction| be |valueDeduction|.
 
 1.  Let |currentValue| be set to the value of [=map/get|getting the value=] of |key|
-    from [=privacy budget store=], with a default of the [=per-site privacy budget=].
+    from [=privacy budget store=],
+    with a default of the [=per-site privacy budget=].
 
 1.  If |deduction| is greater than |currentValue|, return false.
 
 1.  Let |epoch| be the [=epoch index=] component of |key|.
 
 1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
-    of |epoch| from the [=global privacy budget store=], with a default of the [=global privacy budget
+    of |epoch| from the [=global privacy budget store=],
+    with a default of the [=global privacy budget
     per epoch=].
 
 1. If |valueDeduction| is greater than |currentGlobalValue|, return false.
@@ -1284,9 +1285,6 @@ integer |valueDeduction|,
 1.  Return true.
 
 </div>
-
-
-
 
 
 ### Attribution API Activation ### {#s-api-activation}
@@ -1320,7 +1318,7 @@ This flag is initially false.
 
 The API can be invoked if either:
 1.  The [=global attribution API flag=] for the current {{Window}} is true, or
-2.  The current {{Window}} has [=transient activation=] that can be [=consume user activation|consumed=].
+1.  The current {{Window}} has [=transient activation=] that can be [=consume user activation|consumed=].
 
 <p class=note>This approach allows a single user action
 to enable multiple API invocations within the same session,
@@ -1354,13 +1352,17 @@ The length of an [=epoch=] is fixed at one week or 7 [=days=],
 where a <dfn>day</dfn> is defined as 86400 seconds.
 
 The <dfn>epoch start time</dfn> is a [=moment=]
-from the [=wall clock=].  An [=epoch=] starts at a randomly-selected hour of the week
-for each [=user agent=]. This ensures that any bias in aggregates
+from the [=wall clock=].
+An [=epoch=] starts at a randomly-selected hour of the week
+for each [=user agent=].
+This ensures that any bias in aggregates
 that arises from a [=privacy budget=] reaching zero
 is averaged across all the contributions from all [=users=].
 
-<div class=note> On each device the per-site budget and safety limits all share this same epoch
-cadence. </div>
+<div class=note>On the same device,
+all privacy budgets and quotas
+refresh at the same time based on the epoch start time.
+</div>
 
 The start time
 is chosen randomly by the [=user agent=] when an epoch is first needed--
@@ -1400,14 +1402,24 @@ returning an [=epoch index=]:
 
 1.  Let |period| be the [=duration=] of one [=epoch=].
 
-1.  If the [=epoch start time=] is not set:
+1.  If the [=epoch start time=] is not set
+    set it to a randomly selected hour within the last [=epoch=]
+    as follows:
 
-    1.  Let |rounded| be |t|, rounded to the nearest hour
-        of the [=wall clock=].
-
-    1.  Set the [=epoch start time=] to |rounded|, minus a [=duration=]
+    1.  Let |rand| be |t| minus a [=duration=]
         that is randomly selected
         from between 0 (inclusive) and |period| (exclusive).
+    
+    1.  Let |ms| be the number of milliseconds in
+        the [=duration from=] the [=unix epoch=] to |rand|.
+
+    1.  Let |hour| be |ms| divided by 3600000
+        (one hour in milliseconds)
+        rounded towards zero
+        then multiplied by 3600000.
+
+    1.  Set the [=epoch start time=] to the [=unix epoch=]
+        plus |hour| as a [=duration=].
 
 1.  Let |start| be the [=epoch start time=].
 
@@ -1888,12 +1900,13 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 
 1.  Let |deductedGlobalBudgets| be a new [=set=].
 
-1.  For each |epoch| from |currentEpoch| to |startEpoch|, inclusive:
+1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
 
     1.  Let |impressions| be the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |epoch|, and |now|.
 
-        <p class=note>| In the single-epoch case, this is recomputing |matchedImpressions|.
+        <p class=note>In the single-epoch case, this is recomputing |matchedImpressions|.
+        Implementations will want to avoid doing that work twice.
 
     1.  If |impressions| [=set/is empty|is not empty=]:
 
@@ -2149,12 +2162,15 @@ for the following:
     the per-[=site=] [=privacy budget=] per [=epoch=].
 
 <p class=note> Configuring [=safety limits=] as multiples of the per-[=site=] budget determines
-how the API can be used by multiple sites. It is encouraged to consider the expectation of the number
-of sites that might use their budget, maybe adjusted downward for the number of sites that do
-not fully use the budget provided to them.
+how the API can be used by multiple sites.
+In setting this multiple,
+implementations need to consider what they expect to be
+the number of sites that might use their budget,
+maybe adjusted downward to allow for sites
+that do not fully use their budget.
 
 <p class=note>Setting [=safety limits=] as multiples of the per-[=site=] budget
-ensures that exploiting shared limits requires coordination by many sites,
+ensures that exhausting shared limits requires coordination by many sites,
 making them primarily useful as a means of protecting against abuse
 rather than as a primary privacy mechanism.
 

--- a/api.bs
+++ b/api.bs
@@ -1144,7 +1144,7 @@ given a [=privacy budget key=] |key|,
 [[WEBIDL#idl-double|double]] |epsilon|,
 integer |value|,
 integer |maxValue|,
-boolean |isSingleEpoch|, integer |l1Norm|, [=set=] of [=impression site quota keys=] |deductedImpressionQuotas|
+boolean |isSingleEpoch|, integer |l1Norm|, [=set=] of [=privacy budget keys=] |deductedImpressionQuotas|
 and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
 1.  Let |l1NormSensitivity| be |l1Norm| if |isSingleEpoch|, 2 * |value| otherwise.
@@ -1237,7 +1237,7 @@ integer |valueDeduction|,
 
 1.  If |deduction| is greater than |currentValue|, return false.
 
-1.  Let |epoch| be the |epoch index| component of |key|.
+1.  Let |epoch| be the [=epoch index=] component of |key|.
 
 1.  Let |currentGlobalValue| be set to the value of [=map/get|getting the value=]
     of |epoch| from the [=global privacy budget store=], with a default of the [=global privacy budget
@@ -2756,7 +2756,7 @@ and a [=list=] of [=integers=] |histogram|:
 
         <p class=note>The URL for <a enum-value for=AttributionAggregationProtocol>"dap-15-histogram"</a> is expected to identify the DAP Leader role.
         Implementations need to obtain HPKE configuration for both Aggregators statically.
-        The HPKE configuration [=must not=] be fetched on demand, as the time that takes
+        The HPKE configuration <span class=allow-2119>must not</span> be fetched on demand, as the time that takes
         will leak information to callers of <a method for=Attribution>measureConversion()</a>.
 
     1.  Let |serverRole| be 2 for the first item (the Leader)


### PR DESCRIPTION
Creating a PR to add safety limits to the Attribution spec.  This is based primarily on the BigBird algorithm from Section 4 of this paper https://arxiv.org/pdf/2506.05290.  Algorithm 2 is the main algorithm that encompass both budget deduction and safety limit deduction.  


Intended to address this open issue https://github.com/w3c/attribution/issues/237


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bmcase/api/pull/309.html" title="Last updated on Apr 20, 2026, 7:51 PM UTC (646504c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/309/c0cf215...bmcase:646504c.html" title="Last updated on Apr 20, 2026, 7:51 PM UTC (646504c)">Diff</a>