### PR TITLE
Disambiguate links to "users" in specification

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -3056,6 +3056,9 @@ spec:structured header; type:dfn; urlPrefix: https://httpwg.org/specs/rfc9651;
         text: item; url: #item
         text: inner list; url: #inner-list
 </pre>
+<pre class=link-defaults>
+spec:css-2025; type:dfn; text:user
+</pre>
 <pre class=biblio>
 {
   "coppacalypse": {


### PR DESCRIPTION
Previously the build was failing due to ambiguity between the same-named concept in the Privacy Principles specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/311.html" title="Last updated on Nov 13, 2025, 2:18 PM UTC (39d1ea9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/311/2c38eb6...apasel422:39d1ea9.html" title="Last updated on Nov 13, 2025, 2:18 PM UTC (39d1ea9)">Diff</a>