### PR TITLE
Prevent step numbering from restarting in deduct privacy budget

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1148,14 +1148,14 @@ nullable integer |l1Norm|:
 1.  Let |deductionFp| be |sensitivity| / |noiseScale|.
 
 
-<p class=note>Single epoch attributions &mdash;
-the only case that |l1Norm| is non-null &mdash;
-do not cause any cascading effects across epochs.
-Attribution that involves multiple epochs consumes double the budget
-because of the potential for one change to affect attribution across epochs.
-Doubling the deduction assumes that Laplace noise
-proportional to |maxValue| / |epsilon|
-is added to the aggregated histogram.
+    <p class=note>Single epoch attributions &mdash;
+    the only case that |l1Norm| is non-null &mdash;
+    do not cause any cascading effects across epochs.
+    Attribution that involves multiple epochs consumes double the budget
+    because of the potential for one change to affect attribution across epochs.
+    Doubling the deduction assumes that Laplace noise
+    proportional to |maxValue| / |epsilon|
+    is added to the aggregated histogram.
 
 1.  If |deductionFp| is negative or greater than [=maximum epsilon=],
     [=map/set|set=] the value of |key| in the [=privacy budget store=] to 0


### PR DESCRIPTION
Previously, the presence of the note caused the "If deductionFp is negative..." step to restart numbering at 1, instead of continuing at 6.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/314.html" title="Last updated on Nov 13, 2025, 3:06 PM UTC (5a6cc17)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/314/2c38eb6...apasel422:5a6cc17.html" title="Last updated on Nov 13, 2025, 3:06 PM UTC (5a6cc17)">Diff</a>