### PR TITLE
Revert "Parse aggregation service as URL and propagate it to DAP-report creation"

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1530,8 +1530,8 @@ The <dfn method for=Attribution>measureConversion(|options|)</dfn> method steps 
          |implicitInputs|' [=implicit API inputs/top-level site=],
          |implicitInputs|' [=implicit API inputs/intermediary site=], and
          |implicitInputs|' [=implicit API inputs/timestamp=].
-     1.  Let |protocol| be the result of [=map/getting=] |validatedOptions|'s [=validated conversion options/aggregation service URL=] from [=aggregation services=].
-     1.  Switch on the value of |protocol|:
+     1.  Let |aggregationService| be |validatedOptions|'s [=validated conversion options/aggregation service=].
+     1.  Switch on the value of |aggregationService|.{{AttributionAggregationService/protocol}}:
          <dl class="switch">
             :   <a enum-value for=AttributionAggregationProtocol>`dap-15-histogram`</a>
             ::  Perform the following steps:


### PR DESCRIPTION
Reverts w3c/attribution#308


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/323.html" title="Last updated on Nov 21, 2025, 1:26 PM UTC (337d432)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/323/c1ae78c...337d432.html" title="Last updated on Nov 21, 2025, 1:26 PM UTC (337d432)">Diff</a>