### PR TITLE
Bump Python to Bikeshed's minimum required version of 3.12

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - uses: actions/cache@v4
       with:
         path: venv

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
     - uses: actions/setup-node@v4
       with:
         node-version: '>=22'


### PR DESCRIPTION
Previously the build was failing due to use of 3.11.