### PR TITLE
Remove document, frame, and iframe from fetch destinations

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -2021,8 +2021,7 @@ To <dfn noexport>handle Attribution headers</dfn> given a [=request=] |request|
 and [=response=] |response|, run these steps:
 
 1.  If |request|'s [=request/destination=] is not one of the following,
-    return: `""`, `"audio"`, `"document"`, `"frame"`, `"iframe"`, `"image"`,
-    `"script"`, `"track"`, `"video"`.
+    return: `""`, `"audio"`, `"image"`, `"script"`, `"track"`, `"video"`.
 
 1.  If |request|'s [=request/client=] is not a [=secure context=], return.
 


### PR DESCRIPTION
Per https://github.com/w3c/attribution/issues/189#issuecomment-3420830051, who to associate the Save-Impression operation with is unclear in these cases. Support for them could be restored in the future if we hear of use cases and are able to resolve the association question.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/343.html" title="Last updated on Dec 11, 2025, 3:07 PM UTC (1293bbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/343/4c1d110...apasel422:1293bbd.html" title="Last updated on Dec 11, 2025, 3:07 PM UTC (1293bbd)">Diff</a>