### PR TITLE
Replace hardcoded "randomness" in e2e tests with configurable value

### DIFF
--- a/impl/e2e-tests/CONFIG.json
+++ b/impl/e2e-tests/CONFIG.json
@@ -2,6 +2,8 @@
   "aggregationServices": {
     "https://agg-service.example": "dap-15-histogram"
   },
+  "epochStart": 0.5,
+  "fairlyAllocateCreditFraction": 0.5,
   "maxConversionSitesPerImpression": 3,
   "maxConversionCallersPerImpression": 3,
   "maxCreditSize": 10,

--- a/impl/e2e.schema.json
+++ b/impl/e2e.schema.json
@@ -14,6 +14,16 @@
             "format": "uri"
           }
         },
+        "epochStart": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMaximum": 1
+        },
+        "fairlyAllocateCreditFraction": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMaximum": 1
+        },
         "maxConversionCallersPerImpression": {
           "type": "integer",
           "minimum": 0

--- a/impl/src/backend.ts
+++ b/impl/src/backend.ts
@@ -89,7 +89,8 @@ export interface Delegate {
   readonly privacyBudgetEpoch: Temporal.Duration;
 
   now(): Temporal.Instant;
-  random(): number;
+  fairlyAllocateCreditFraction(): number;
+  epochStart(): number;
 }
 
 function allZeroHistogram(size: number): number[] {
@@ -551,7 +552,7 @@ export class Backend {
     credit = credit.slice(0, N);
 
     const normalizedCredit = fairlyAllocateCredit(credit, value, () =>
-      this.#delegate.random(),
+      this.#delegate.fairlyAllocateCreditFraction(),
     );
 
     const histogram = allZeroHistogram(histogramSize);
@@ -575,7 +576,7 @@ export class Backend {
     const period = this.#delegate.privacyBudgetEpoch.total("seconds");
     let start = this.#epochStartStore.get(site);
     if (start === undefined) {
-      const p = checkRandom(this.#delegate.random());
+      const p = checkRandom(this.#delegate.epochStart());
       const dur = Temporal.Duration.from({
         seconds: p * period,
       });

--- a/impl/src/e2e.test.ts
+++ b/impl/src/e2e.test.ts
@@ -107,7 +107,8 @@ function runTest(
     privacyBudgetEpoch: days(config.privacyBudgetEpochDays),
 
     now: () => now,
-    random: () => 0.5,
+    fairlyAllocateCreditFraction: () => config.fairlyAllocateCreditFraction,
+    epochStart: () => config.epochStart,
   });
 
   for (const event of tc.events) {

--- a/impl/src/fixture.ts
+++ b/impl/src/fixture.ts
@@ -15,6 +15,8 @@ export interface TestConfig {
   maxHistogramSize: number;
   privacyBudgetMicroEpsilons: number;
   privacyBudgetEpochDays: number;
+  epochStart: number;
+  fairlyAllocateCreditFraction: number;
 }
 
 export function makeBackend(
@@ -40,6 +42,7 @@ export function makeBackend(
     privacyBudgetEpoch: days(config.privacyBudgetEpochDays),
 
     now: () => now,
-    random: () => 0.5,
+    fairlyAllocateCreditFraction: () => config.fairlyAllocateCreditFraction,
+    epochStart: () => config.epochStart,
   });
 }

--- a/impl/src/simulator.ts
+++ b/impl/src/simulator.ts
@@ -25,7 +25,8 @@ const backend = new Backend({
   privacyBudgetEpoch: days(7),
 
   now: () => now,
-  random: () => 0.5,
+  fairlyAllocateCreditFraction: () => 0.5,
+  epochStart: () => 0.5,
 });
 
 function numberOrUndefined(input: HTMLInputElement): number | undefined {


### PR DESCRIPTION
To make those tests less dependent on fixed behavior.

In the future, we might consider allowing these values to be specified in individual events at a higher level in order to avoid mandating the exact way in which randomness is used.