### PR TITLE
Require e2e tests to conform to WebIDL definitions

### DIFF
--- a/impl/e2e-tests/save-impression-errors.json
+++ b/impl/e2e-tests/save-impression-errors.json
@@ -1,13 +1,6 @@
 {
   "events": [
     {
-      "seconds": 1,
-      "site": "publisher.example",
-      "event": "saveImpression",
-      "options": { "histogramIndex": -1 },
-      "expectedError": "RangeError"
-    },
-    {
       "seconds": 2,
       "site": "publisher.example",
       "event": "saveImpression",

--- a/impl/e2e.schema.json
+++ b/impl/e2e.schema.json
@@ -103,8 +103,7 @@
                       {
                         "type": "array",
                         "items": {
-                          "type": "integer",
-                          "minimum": 0
+                          "$ref": "#/$defs/unsignedLong"
                         }
                       },
                       {
@@ -171,7 +170,7 @@
           "type": "number"
         },
         "histogramSize": {
-          "type": "integer"
+          "$ref": "#/$defs/unsignedLong"
         },
         "impressionCallers": {
           "$ref": "#/$defs/siteList"
@@ -180,19 +179,19 @@
           "$ref": "#/$defs/siteList"
         },
         "lookbackDays": {
-          "type": "integer"
+          "$ref": "#/$defs/unsignedLong"
         },
         "matchValues": {
           "type": "array",
           "items": {
-            "type": "integer"
+            "$ref": "#/$defs/unsignedLong"
           }
         },
         "maxValue": {
-          "type": "integer"
+          "$ref": "#/$defs/unsignedLong"
         },
         "value": {
-          "type": "integer"
+          "$ref": "#/$defs/unsignedLong"
         }
       },
       "required": ["aggregationService", "histogramSize"],
@@ -208,16 +207,16 @@
           "$ref": "#/$defs/siteList"
         },
         "histogramIndex": {
-          "type": "integer"
+          "$ref": "#/$defs/unsignedLong"
         },
         "lifetimeDays": {
-          "type": "integer"
+          "$ref": "#/$defs/unsignedLong"
         },
         "matchValue": {
-          "type": "integer"
+          "$ref": "#/$defs/unsignedLong"
         },
         "priority": {
-          "type": "integer"
+          "$ref": "#/$defs/long"
         }
       },
       "required": ["histogramIndex"],
@@ -283,6 +282,16 @@
       "items": {
         "type": "string"
       }
+    },
+    "long": {
+      "type": "integer",
+      "minimum": -2147483648,
+      "maximum": 2147483647
+    },
+    "unsignedLong": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 4294967295
     }
   }
 }


### PR DESCRIPTION
The WebIDL interfaces for `AttributionImpressionOptions` and `AttributionConversionOptions` specify multiple fields as either [`unsigned long`](https://webidl.spec.whatwg.org/#idl-unsigned-long) or [`long`](https://webidl.spec.whatwg.org/#idl-long), and therefore no e2e test should attempt to pass values outside these ranges, as the associated type conversion (e.g. from JavaScript) is assumed to occur strictly before the API (i.e. the simulator) receives the final values.

Enforcing this at the JSON schema level ensures that test suites that import the e2e tests need not concern themselves with the WebIDL-level conversions.

The change to the JSON schema revealed one such offending test case in `save-impression-errors.json`, which attempted to pass `histogramIndex: -1`.