### PR TITLE
Add a license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,3 @@
+# Attribution API: https://github.com/w3c/attribution
+
+Copyright © 2026 World Wide Web Consortium. All Rights Reserved. This work is distributed under [the W3C® Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software) in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


### PR DESCRIPTION
Source from https://www.w3.org/Consortium/Legal/2023/copyright-software-short-notice.html As linked from https://www.w3.org/copyright/software-license-2023/

Closes #346.