### PR TITLE
Add e2e test for disabled API

### DIFF
--- a/impl/e2e-tests/api-disabled.json
+++ b/impl/e2e-tests/api-disabled.json
@@ -1,0 +1,77 @@
+{
+  "$comment": "The specification does not require that impressions saved before the API was disabled are retained once it is re-enabled, so we do not test that here",
+  "events": [
+    {
+      "seconds": 1,
+      "event": "disableAPI"
+    },
+    {
+      "seconds": 2,
+      "site": "publisher.example",
+      "event": "saveImpression",
+      "options": {
+        "histogramIndex": 0,
+        "lifetimeDays": 0
+      },
+      "$comment": "Impression options are still validated even when the API is disabled",
+      "expectedError": "RangeError"
+    },
+    {
+      "seconds": 3,
+      "site": "publisher.example",
+      "event": "saveImpression",
+      "options": {
+        "histogramIndex": 0
+      }
+    },
+    {
+      "seconds": 4,
+      "event": "enableAPI"
+    },
+    {
+      "seconds": 5,
+      "site": "advertiser.example",
+      "event": "measureConversion",
+      "options": {
+        "aggregationService": "https://agg-service.example",
+        "histogramSize": 1
+      },
+      "$comment": "The valid impression should not have been saved while the API was disabled",
+      "expected": [0]
+    },
+    {
+      "seconds": 6,
+      "site": "publisher.example",
+      "event": "saveImpression",
+      "options": {
+        "histogramIndex": 0
+      }
+    },
+    {
+      "seconds": 7,
+      "event": "disableAPI"
+    },
+    {
+      "seconds": 8,
+      "site": "advertiser.example",
+      "event": "measureConversion",
+      "options": {
+        "aggregationService": "https://agg-service.example",
+        "histogramSize": 0
+      },
+      "$comment": "Conversion options are still validated even when the API is disabled...",
+      "expected": "RangeError"
+    },
+    {
+      "seconds": 9,
+      "site": "advertiser.example",
+      "event": "measureConversion",
+      "options": {
+        "aggregationService": "https://agg-service.example",
+        "histogramSize": 1
+      },
+      "$comment": "... But valid conversion options only result in all-zero reports, despite the would-be-matching impression",
+      "expected": [0]
+    }
+  ]
+}

--- a/impl/e2e.schema.json
+++ b/impl/e2e.schema.json
@@ -163,6 +163,24 @@
                 },
                 "required": ["forgetVisits", "sites"],
                 "unevaluatedProperties": false
+              },
+              {
+                "$ref": "#/$defs/commonEvent",
+                "properties": {
+                  "event": {
+                    "const": "enableAPI"
+                  }
+                },
+                "unevaluatedProperties": false
+              },
+              {
+                "$ref": "#/$defs/commonEvent",
+                "properties": {
+                  "event": {
+                    "const": "disableAPI"
+                  }
+                },
+                "unevaluatedProperties": false
               }
             ]
           }

--- a/impl/src/e2e.test.ts
+++ b/impl/src/e2e.test.ts
@@ -23,7 +23,9 @@ type Event =
   | SaveImpression
   | MeasureConversion
   | ClearImpressionsForSite
-  | ClearBrowsingHistoryForAttribution;
+  | ClearBrowsingHistoryForAttribution
+  | EnableAPI
+  | DisableAPI;
 
 type ExpectedError =
   | "RangeError"
@@ -62,6 +64,16 @@ interface ClearBrowsingHistoryForAttribution {
   seconds: number;
   sites: string[];
   forgetVisits: boolean;
+}
+
+interface EnableAPI {
+  event: "enableAPI";
+  seconds: number;
+}
+
+interface DisableAPI {
+  event: "disableAPI";
+  seconds: number;
 }
 
 function assertThrows(
@@ -164,6 +176,12 @@ function runTest(
         break;
       case "clearBrowsingHistoryForAttribution":
         backend.clearState(event.sites, event.forgetVisits);
+        break;
+      case "enableAPI":
+        backend.enabled = true;
+        break;
+      case "disableAPI":
+        backend.enabled = false;
         break;
     }
   }


### PR DESCRIPTION
1. Impression/conversion options are still validated while the API is disabled.
2. Impressions are not saved while the API is disabled.
3. Only all-zero histograms are produced while the API is disabled.