### PR TITLE
Limits on saving impressions

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1903,7 +1903,7 @@ will determine which saved [=impressions=] are available for conversions.
 
 Implementations [=must=] set a [=maximum lookback=] of at least 30 days.
 Within this period, implementations [=should=] attempt to retain
-at least 1000 impressions per site.
+at least 1000 impressions per [=impression site=].
 
 Implementations [=should=] retain impressions
 beyond these recommended limits on time and number where possible.


### PR DESCRIPTION
A more thorough treatment of expectations.

This covers the recommendations:
* 30 days
* 1000 impressions

These are minimums and implementations should try to store more. Explain why these can't be hard limits,
so they cannot be relied on.

Closes #190.
Closes #381.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/382.html" title="Last updated on Feb 18, 2026, 11:48 PM UTC (953cad2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/382/5a6e405...953cad2.html" title="Last updated on Feb 18, 2026, 11:48 PM UTC (953cad2)">Diff</a>