### PR TITLE
clear matched impressions after using for L1 norm computation

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1409,7 +1409,7 @@ returning an [=epoch index=]:
     1.  Let |rand| be |t| minus a [=duration=]
         that is randomly selected
         from between 0 (inclusive) and |period| (exclusive).
-    
+
     1.  Let |ms| be the number of milliseconds in
         the [=duration from=] the [=unix epoch=] to |rand|.
 
@@ -1893,6 +1893,8 @@ To <dfn>do attribution and fill a histogram</dfn>, given
         |options|' [=validated conversion options/credit=].
 
     1.  Set |l1Norm| be the sum of the [=list/items=] in |histogram|.
+
+    1.  Set |matchedImpressions| back to an [=set/is empty|empty=] [=set=].
 
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
 

--- a/api.bs
+++ b/api.bs
@@ -1864,8 +1864,6 @@ To <dfn>do attribution and fill a histogram</dfn>, given
   [=site=] or `undefined` |intermediarySite|, and
   [=moment=] |now|:
 
-1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
-
 1.  Let |currentEpoch| be the result of [=get the current epoch=]
     with |now|.
 
@@ -1880,27 +1878,27 @@ To <dfn>do attribution and fill a histogram</dfn>, given
 1.  Let |l1Norm| be 0.
 
 1.  If |isSingleEpoch| is true:
-    1.  Set |matchedImpressions| to the result of invoking [=common matching logic=]
+    1.  Let |impressions| to the result of invoking [=common matching logic=]
         with |options|, |topLevelSite|, |intermediarySite|, |currentEpoch|, and |now|.
 
-    1.  If |matchedImpressions| [=set/is empty=], return the result of invoking
+    1.  If |impressions| [=set/is empty=], return the result of invoking
           [=create an all-zero histogram=] with
           |options|' [=validated conversion options/histogram size=].
 
-    1.  Let |histogram| be the result of [=fill a histogram with last-n-touch attribution=] with |matchedImpressions|,
+    1.  Let |histogram| be the result of [=fill a histogram with last-n-touch attribution=] with |impressions|,
         |options|' [=validated conversion options/histogram size=],
         |options|' [=validated conversion options/value=], and
         |options|' [=validated conversion options/credit=].
 
     1.  Set |l1Norm| be the sum of the [=list/items=] in |histogram|.
 
-    1.  Set |matchedImpressions| back to an [=set/is empty|empty=] [=set=].
-
     1.  [=Assert=]: |l1Norm| is less than or equal to |options|' [=validated conversion options/value=].
 
 1.  Let |deductedImpressionQuotas| be a new [=set=].
 
 1.  Let |deductedGlobalBudgets| be a new [=set=].
+
+1.  Let |matchedImpressions| be an [=set/is empty|empty=] [=set=].
 
 1.  For each |epoch| from |startEpoch| to |currentEpoch|, inclusive:
 


### PR DESCRIPTION
The first computation with matched impressions is really just computing the L1 norm. After that we want to clear it otherwise there may be data left in it when we go on to the forward loop over epochs and if the budget checks don't pass we will not add anything to it but it could still have entries it in if we don't clear it here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bmcase/api/pull/407.html" title="Last updated on Apr 21, 2026, 2:58 PM UTC (9e71c37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/407/904ab26...bmcase:9e71c37.html" title="Last updated on Apr 21, 2026, 2:58 PM UTC (9e71c37)">Diff</a>