### PR TITLE
Cleanup images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ images:
 	@echo "Regenerating images"
 	for i in $(IMAGES); do \
 	  tmp="$$(mktemp)"; \
-	  npx aasvg --extract --embed <"$$i" >"$$tmp" && mv "$$tmp" "$$i"; \
+	  npx aasvg extract embed arrow=line <"$$i" >"$$tmp" && mv "$$tmp" "$$i"; \
 	done
 
 simulator: build/simulator.html build/simulator.js

--- a/api.bs
+++ b/api.bs
@@ -20,23 +20,6 @@ Org: W3C
 Level: None
 </pre>
 
-<style>
-/* dark mode haxx for diagrams
-   No nesting, thanks to https://github.com/validator/validator/issues/1820 */
-svg.diagram :is([stroke="black"], [stroke^="#000"]) {
-  stroke: var(--text);
-}
-svg.diagram :is([stroke="white"], [stroke^="#fff"]) {
-  stroke: var(--bg);
-}
-svg.diagram :is([fill="black"], [fill^="#000"], :not([fill])) {
-  fill: var(--text);
-}
-svg.diagram :is([fill="white"], [fill^="#fff"]) {
-  fill: var(--bg);
-}
-</style>
-
 
 # Introduction # {#intro}
 

--- a/images/budget.svg
+++ b/images/budget.svg
@@ -1,4 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="192" width="496" viewBox="0 0 496 192" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="192" width="496" viewBox="0 0 496 192" class="aasvg">
+<style>
+:root { color-scheme: light dark; --aasvg-b: light-dark(black, white); --aasvg-w: light-dark(white, black); }
+* { fill: none; stroke: var(--aasvg-b); stroke-linecap: round; }
+.dashed { stroke-dasharray: 3,6; }
+text { font: 13px monospace; text-anchor: middle; fill: var(--aasvg-b); stroke: none; }
+.dot.closed { fill: var(--aasvg-b); }
+.dot:is(.open, .xor) { fill: var(--aasvg-w); }
+.dot.dotted { fill: var(--aasvg-w); stroke-dasharray: 0,1.8; }
+.dot.shaded { fill: #666; }
+</style>
 <text class="ascii" display="none"><![CDATA[
         |         |         |         |         |   ║
 Site A  |       o |         |         |        o|   ║
@@ -12,51 +22,51 @@ Site E  |         |         |         |*        | * ║
              |         |         |         |        |
           week 1     week 2   week 3   week 4      now
 ]]></text>
-<path d="M 72,16 L 72,128" fill="none" stroke="black"/>
-<path d="M 152,16 L 152,128" fill="none" stroke="black"/>
-<path d="M 232,16 L 232,128" fill="none" stroke="black"/>
-<path d="M 312,16 L 312,128" fill="none" stroke="black"/>
-<path d="M 392,16 L 392,128" fill="none" stroke="black"/>
-<path d="M 426,16 L 426,128" fill="none" stroke="black"/><path d="M 422,16 L 422,128" fill="none" stroke="black"/>
-<path d="M 424,136 L 424,160" fill="none" stroke="black"/>
-<path d="M 40,128 L 448,128" fill="none" stroke="black"/>
-<path d="M 88,144 L 96,144" fill="none" stroke="black"/>
-<path d="M 128,144 L 136,144" fill="none" stroke="black"/>
-<path d="M 168,144 L 176,144" fill="none" stroke="black"/>
-<path d="M 208,144 L 216,144" fill="none" stroke="black"/>
-<path d="M 248,144 L 256,144" fill="none" stroke="black"/>
-<path d="M 288,144 L 296,144" fill="none" stroke="black"/>
-<path d="M 328,144 L 336,144" fill="none" stroke="black"/>
-<path d="M 368,144 L 376,144" fill="none" stroke="black"/>
-<path d="M 88,144 C 79.16936,144 72,136.83064 72,128" fill="none" stroke="black"/>
-<path d="M 96,144 C 104.83064,144 112,151.16936 112,160" fill="none" stroke="black"/>
-<path d="M 128,144 C 119.16936,144 112,151.16936 112,160" fill="none" stroke="black"/>
-<path d="M 136,144 C 144.83064,144 152,136.83064 152,128" fill="none" stroke="black"/>
-<path d="M 168,144 C 159.16936,144 152,136.83064 152,128" fill="none" stroke="black"/>
-<path d="M 176,144 C 184.83064,144 192,151.16936 192,160" fill="none" stroke="black"/>
-<path d="M 208,144 C 199.16936,144 192,151.16936 192,160" fill="none" stroke="black"/>
-<path d="M 216,144 C 224.83064,144 232,136.83064 232,128" fill="none" stroke="black"/>
-<path d="M 248,144 C 239.16936,144 232,136.83064 232,128" fill="none" stroke="black"/>
-<path d="M 256,144 C 264.83064,144 272,151.16936 272,160" fill="none" stroke="black"/>
-<path d="M 288,144 C 279.16936,144 272,151.16936 272,160" fill="none" stroke="black"/>
-<path d="M 296,144 C 304.83064,144 312,136.83064 312,128" fill="none" stroke="black"/>
-<path d="M 328,144 C 319.16936,144 312,136.83064 312,128" fill="none" stroke="black"/>
-<path d="M 336,144 C 344.83064,144 352,151.16936 352,160" fill="none" stroke="black"/>
-<path d="M 368,144 C 359.16936,144 352,151.16936 352,160" fill="none" stroke="black"/>
-<path d="M 376,144 C 384.83064,144 392,136.83064 392,128" fill="none" stroke="black"/>
-<polygon class="arrowhead" points="456,128 444,122.4 444,133.6" fill="black" transform="rotate(0,448,128)"/>
-<polygon class="arrowhead" points="432,136 420,130.4 420,141.6" fill="black" transform="rotate(270,424,136)"/>
-<circle cx="96" cy="64" r="6" class="opendot" fill="white" stroke="black"/>
-<circle cx="112" cy="64" r="6" class="closeddot" fill="black"/>
-<circle cx="136" cy="32" r="6" class="opendot" fill="white" stroke="black"/>
-<circle cx="216" cy="48" r="6" class="opendot" fill="white" stroke="black"/>
-<circle cx="240" cy="48" r="6" class="closeddot" fill="black"/>
-<circle cx="240" cy="64" r="6" class="opendot" fill="white" stroke="black"/>
-<circle cx="256" cy="48" r="6" class="closeddot" fill="black"/>
-<circle cx="320" cy="96" r="6" class="closeddot" fill="black"/>
-<circle cx="328" cy="48" r="6" class="opendot" fill="white" stroke="black"/>
-<circle cx="384" cy="32" r="6" class="opendot" fill="white" stroke="black"/>
-<circle cx="408" cy="96" r="6" class="closeddot" fill="black"/>
+<path d="M 72,16L 72,128"/>
+<path d="M 152,16L 152,128"/>
+<path d="M 232,16L 232,128"/>
+<path d="M 312,16L 312,128"/>
+<path d="M 392,16L 392,128"/>
+<path d="M 426,16L 426,128"/><path d="M 422,16L 422,128"/>
+<path d="M 424,129.18235L 424,160"/>
+<path d="M 40,128L 454.81765,128"/>
+<path d="M 88,144L 96,144"/>
+<path d="M 128,144L 136,144"/>
+<path d="M 168,144L 176,144"/>
+<path d="M 208,144L 216,144"/>
+<path d="M 248,144L 256,144"/>
+<path d="M 288,144L 296,144"/>
+<path d="M 328,144L 336,144"/>
+<path d="M 368,144L 376,144"/>
+<path d="M 88,144C 79.16936,144 72,136.83064 72,128"/>
+<path d="M 96,144C 104.83064,144 112,151.16936 112,160"/>
+<path d="M 128,144C 119.16936,144 112,151.16936 112,160"/>
+<path d="M 136,144C 144.83064,144 152,136.83064 152,128"/>
+<path d="M 168,144C 159.16936,144 152,136.83064 152,128"/>
+<path d="M 176,144C 184.83064,144 192,151.16936 192,160"/>
+<path d="M 208,144C 199.16936,144 192,151.16936 192,160"/>
+<path d="M 216,144C 224.83064,144 232,136.83064 232,128"/>
+<path d="M 248,144C 239.16936,144 232,136.83064 232,128"/>
+<path d="M 256,144C 264.83064,144 272,151.16936 272,160"/>
+<path d="M 288,144C 279.16936,144 272,151.16936 272,160"/>
+<path d="M 296,144C 304.83064,144 312,136.83064 312,128"/>
+<path d="M 328,144C 319.16936,144 312,136.83064 312,128"/>
+<path d="M 336,144C 344.83064,144 352,151.16936 352,160"/>
+<path d="M 368,144C 359.16936,144 352,151.16936 352,160"/>
+<path d="M 376,144C 384.83064,144 392,136.83064 392,128"/>
+<path class="arrowhead" d="M 443.78856,122.85309 L 454.81765,128 L 443.78856,133.14691"/>
+<path class="arrowhead" d="M 418.85309,140.21144 L 424,129.18235 L 429.14691,140.21144"/>
+<circle cx="96" cy="64" r="7" class="dot open"/>
+<circle cx="112" cy="64" r="7" class="dot closed"/>
+<circle cx="136" cy="32" r="7" class="dot open"/>
+<circle cx="216" cy="48" r="7" class="dot open"/>
+<circle cx="240" cy="48" r="7" class="dot closed"/>
+<circle cx="240" cy="64" r="7" class="dot open"/>
+<circle cx="256" cy="48" r="7" class="dot closed"/>
+<circle cx="320" cy="96" r="7" class="dot closed"/>
+<circle cx="328" cy="48" r="7" class="dot open"/>
+<circle cx="384" cy="32" r="7" class="dot open"/>
+<circle cx="408" cy="96" r="7" class="dot closed"/>
 <g class="text">
 <text x="28" y="36">Site A</text>
 <text x="28" y="52">Site B</text>

--- a/images/histogram.svg
+++ b/images/histogram.svg
@@ -1,4 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="192" width="264" viewBox="0 0 264 192" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="192" width="264" viewBox="0 0 264 192" class="aasvg">
+<style>
+:root { color-scheme: light dark; --aasvg-b: light-dark(black, white); --aasvg-w: light-dark(white, black); }
+* { fill: none; stroke: var(--aasvg-b); stroke-linecap: round; }
+.dashed { stroke-dasharray: 3,6; }
+text { font: 13px monospace; text-anchor: middle; fill: var(--aasvg-b); stroke: none; }
+</style>
 <text class="ascii" display="none"><![CDATA[
 |
 +------+
@@ -12,16 +18,16 @@
 +-+
 |
 ]]></text>
-<path d="M 8,16 L 8,176" fill="none" stroke="black"/>
-<path d="M 24,128 L 24,160" fill="none" stroke="black"/>
-<path d="M 64,32 L 64,64" fill="none" stroke="black"/>
-<path d="M 88,96 L 88,128" fill="none" stroke="black"/>
-<path d="M 152,64 L 152,96" fill="none" stroke="black"/>
-<path d="M 8,32 L 64,32" fill="none" stroke="black"/>
-<path d="M 8,64 L 152,64" fill="none" stroke="black"/>
-<path d="M 8,96 L 152,96" fill="none" stroke="black"/>
-<path d="M 8,128 L 88,128" fill="none" stroke="black"/>
-<path d="M 8,160 L 24,160" fill="none" stroke="black"/>
+<path d="M 8,16L 8,176"/>
+<path d="M 24,128L 24,160"/>
+<path d="M 64,32L 64,64"/>
+<path d="M 88,96L 88,128"/>
+<path d="M 152,64L 152,96"/>
+<path d="M 8,32L 64,32"/>
+<path d="M 8,64L 152,64"/>
+<path d="M 8,96L 152,96"/>
+<path d="M 8,128L 88,128"/>
+<path d="M 8,160L 24,160"/>
 <g class="text">
 <text x="120" y="52">example.com</text>
 <text x="212" y="84">news.example</text>

--- a/images/overview.svg
+++ b/images/overview.svg
@@ -1,4 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="592" width="616" viewBox="0 0 616 592" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="592" width="616" viewBox="0 0 616 592" class="aasvg">
+<style>
+:root { color-scheme: light dark; --aasvg-b: light-dark(black, white); --aasvg-w: light-dark(white, black); }
+* { fill: none; stroke: var(--aasvg-b); stroke-linecap: round; }
+.dashed { stroke-dasharray: 3,6; }
+text { font: 13px monospace; text-anchor: middle; fill: var(--aasvg-b); stroke: none; }
+</style>
 <text class="ascii" display="none"><![CDATA[
                                                   Conversion
                                  +--------------+ Reports    +-------------+
@@ -37,63 +43,63 @@ saveImpression |     measureConversion |   | Conversion
                       |             |
                        '-----------'
 ]]></text>
-<path d="M 48,368 L 48,432" fill="none" stroke="black"/>
-<path d="M 72,208 L 72,288" fill="none" stroke="black"/>
-<path d="M 128,288 L 128,360" fill="none" stroke="black"/>
-<path d="M 184,208 L 184,288" fill="none" stroke="black"/>
-<path d="M 184,512 L 184,560" fill="none" stroke="black"/>
-<path d="M 200,208 L 200,288" fill="none" stroke="black"/>
-<path d="M 216,208 L 216,288" fill="none" stroke="black"/>
-<path d="M 240,440 L 240,488" fill="none" stroke="black"/>
-<path d="M 272,32 L 272,112" fill="none" stroke="black"/>
-<path d="M 272,208 L 272,288" fill="none" stroke="black"/>
-<path d="M 296,512 L 296,560" fill="none" stroke="black"/>
-<path d="M 320,288 L 320,360" fill="none" stroke="black"/>
-<path d="M 352,120 L 352,208" fill="none" stroke="black"/>
-<path d="M 352,296 L 352,368" fill="none" stroke="black"/>
-<path d="M 368,120 L 368,160" fill="none" stroke="black"/>
-<path d="M 384,120 L 384,144" fill="none" stroke="black"/>
-<path d="M 392,32 L 392,112" fill="none" stroke="black"/>
-<path d="M 392,208 L 392,288" fill="none" stroke="black"/>
-<path d="M 432,368 L 432,432" fill="none" stroke="black"/>
-<path d="M 480,192 L 480,208" fill="none" stroke="black"/>
-<path d="M 496,32 L 496,112" fill="none" stroke="black"/>
-<path d="M 496,176 L 496,208" fill="none" stroke="black"/>
-<path d="M 608,32 L 608,112" fill="none" stroke="black"/>
-<path d="M 272,32 L 392,32" fill="none" stroke="black"/>
-<path d="M 496,32 L 608,32" fill="none" stroke="black"/>
-<path d="M 392,46 L 488,46" fill="none" stroke="black"/><path d="M 392,50 L 488,50" fill="none" stroke="black"/>
-<path d="M 400,96 L 496,96" fill="none" stroke="black"/>
-<path d="M 272,112 L 392,112" fill="none" stroke="black"/>
-<path d="M 496,112 L 608,112" fill="none" stroke="black"/>
-<path d="M 400,160 L 480,160" fill="none" stroke="black"/>
-<path d="M 384,176 L 464,176" fill="none" stroke="black"/>
-<path d="M 72,208 L 216,208" fill="none" stroke="black"/>
-<path d="M 272,208 L 392,208" fill="none" stroke="black"/>
-<path d="M 72,288 L 216,288" fill="none" stroke="black"/>
-<path d="M 272,288 L 392,288" fill="none" stroke="black"/>
-<path d="M 48,368 L 432,368" fill="none" stroke="black"/>
-<path d="M 48,432 L 432,432" fill="none" stroke="black"/>
-<path d="M 200,496 L 280,496" fill="none" stroke="black"/>
-<path d="M 200,576 L 280,576" fill="none" stroke="black"/>
-<path d="M 400,160 C 391.16936,160 384,152.83064 384,144" fill="none" stroke="black"/>
-<path d="M 480,160 C 488.83064,160 496,167.16936 496,176" fill="none" stroke="black"/>
-<path d="M 384,176 C 375.16936,176 368,168.83064 368,160" fill="none" stroke="black"/>
-<path d="M 464,176 C 472.83064,176 480,183.16936 480,192" fill="none" stroke="black"/>
-<path d="M 200,496 C 191.16936,496 184,503.16936 184,512" fill="none" stroke="black"/>
-<path d="M 280,496 C 288.83064,496 296,503.16936 296,512" fill="none" stroke="black"/>
-<path d="M 200,576 C 191.16936,576 184,568.83064 184,560" fill="none" stroke="black"/>
-<path d="M 280,576 C 288.83064,576 296,568.83064 296,560" fill="none" stroke="black"/>
-<polygon class="arrowhead" points="496,48 484,42.4 484,53.6" fill="black" transform="rotate(0,488,48)"/>
-<polygon class="arrowhead" points="408,96 396,90.4 396,101.6" fill="black" transform="rotate(180,400,96)"/>
-<polygon class="arrowhead" points="392,120 380,114.4 380,125.6" fill="black" transform="rotate(270,384,120)"/>
-<polygon class="arrowhead" points="376,120 364,114.4 364,125.6" fill="black" transform="rotate(270,368,120)"/>
-<polygon class="arrowhead" points="360,296 348,290.4 348,301.6" fill="black" transform="rotate(270,352,296)"/>
-<polygon class="arrowhead" points="360,120 348,114.4 348,125.6" fill="black" transform="rotate(270,352,120)"/>
-<polygon class="arrowhead" points="328,360 316,354.4 316,365.6" fill="black" transform="rotate(90,320,360)"/>
-<polygon class="arrowhead" points="248,488 236,482.4 236,493.6" fill="black" transform="rotate(90,240,488)"/>
-<polygon class="arrowhead" points="248,440 236,434.4 236,445.6" fill="black" transform="rotate(270,240,440)"/>
-<polygon class="arrowhead" points="136,360 124,354.4 124,365.6" fill="black" transform="rotate(90,128,360)"/>
+<path d="M 48,368L 48,432"/>
+<path d="M 72,208L 72,288"/>
+<path d="M 128,288L 128,366.81765"/>
+<path d="M 184,208L 184,288"/>
+<path d="M 184,512L 184,560"/>
+<path d="M 200,208L 200,288"/>
+<path d="M 216,208L 216,288"/>
+<path d="M 240,433.18235L 240,494.81765"/>
+<path d="M 272,32L 272,112"/>
+<path d="M 272,208L 272,288"/>
+<path d="M 296,512L 296,560"/>
+<path d="M 320,288L 320,366.81765"/>
+<path d="M 352,113.18235L 352,208"/>
+<path d="M 352,289.18235L 352,368"/>
+<path d="M 368,113.18235L 368,160"/>
+<path d="M 384,113.18235L 384,144"/>
+<path d="M 392,32L 392,112"/>
+<path d="M 392,208L 392,288"/>
+<path d="M 432,368L 432,432"/>
+<path d="M 480,192L 480,208"/>
+<path d="M 496,32L 496,112"/>
+<path d="M 496,176L 496,208"/>
+<path d="M 608,32L 608,112"/>
+<path d="M 272,32L 392,32"/>
+<path d="M 496,32L 608,32"/>
+<path d="M 392,46L 490.53193,46"/><path d="M 392,50L 490.53193,50"/>
+<path d="M 393.18235,96L 496,96"/>
+<path d="M 272,112L 392,112"/>
+<path d="M 496,112L 608,112"/>
+<path d="M 400,160L 480,160"/>
+<path d="M 384,176L 464,176"/>
+<path d="M 72,208L 216,208"/>
+<path d="M 272,208L 392,208"/>
+<path d="M 72,288L 216,288"/>
+<path d="M 272,288L 392,288"/>
+<path d="M 48,368L 432,368"/>
+<path d="M 48,432L 432,432"/>
+<path d="M 200,496L 280,496"/>
+<path d="M 200,576L 280,576"/>
+<path d="M 400,160C 391.16936,160 384,152.83064 384,144"/>
+<path d="M 480,160C 488.83064,160 496,167.16936 496,176"/>
+<path d="M 384,176C 375.16936,176 368,168.83064 368,160"/>
+<path d="M 464,176C 472.83064,176 480,183.16936 480,192"/>
+<path d="M 200,496C 191.16936,496 184,503.16936 184,512"/>
+<path d="M 280,496C 288.83064,496 296,503.16936 296,512"/>
+<path d="M 200,576C 191.16936,576 184,568.83064 184,560"/>
+<path d="M 280,576C 288.83064,576 296,568.83064 296,560"/>
+<path class="arrowhead" d="M 483.78856,42.85309 L 494.81765,48 L 483.78856,53.14691"/>
+<path class="arrowhead" d="M 404.21144,101.14691 L 393.18235,96 L 404.21144,90.85309"/>
+<path class="arrowhead" d="M 378.85309,124.21144 L 384,113.18235 L 389.14691,124.21144"/>
+<path class="arrowhead" d="M 362.85309,124.21144 L 368,113.18235 L 373.14691,124.21144"/>
+<path class="arrowhead" d="M 346.85309,300.21144 L 352,289.18235 L 357.14691,300.21144"/>
+<path class="arrowhead" d="M 346.85309,124.21144 L 352,113.18235 L 357.14691,124.21144"/>
+<path class="arrowhead" d="M 325.14691,355.78856 L 320,366.81765 L 314.85309,355.78856"/>
+<path class="arrowhead" d="M 245.14691,483.78856 L 240,494.81765 L 234.85309,483.78856"/>
+<path class="arrowhead" d="M 234.85309,444.21144 L 240,433.18235 L 245.14691,444.21144"/>
+<path class="arrowhead" d="M 133.14691,355.78856 L 128,366.81765 L 122.85309,355.78856"/>
 <g class="text">
 <text x="444" y="20">Conversion</text>
 <text x="432" y="36">Reports</text>

--- a/images/value.svg
+++ b/images/value.svg
@@ -1,4 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="272" width="432" viewBox="0 0 432 272" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px" stroke-linecap="round">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="272" width="432" viewBox="0 0 432 272" class="aasvg">
+<style>
+:root { color-scheme: light dark; --aasvg-b: light-dark(black, white); --aasvg-w: light-dark(white, black); }
+* { fill: none; stroke: var(--aasvg-b); stroke-linecap: round; }
+.dashed { stroke-dasharray: 3,6; }
+text { font: 13px monospace; text-anchor: middle; fill: var(--aasvg-b); stroke: none; }
+</style>
 <text class="ascii" display="none"><![CDATA[
 +-------------+            +------------+
 |             |            |            |
@@ -17,36 +23,36 @@
 | Improvement |            |            |   etc...
  '-----------'             +------------+
 ]]></text>
-<path d="M 8,16 L 8,80" fill="none" stroke="black"/>
-<path d="M 8,176 L 8,240" fill="none" stroke="black"/>
-<path d="M 56,88 L 56,160" fill="none" stroke="black"/>
-<path d="M 120,16 L 120,80" fill="none" stroke="black"/>
-<path d="M 120,176 L 120,240" fill="none" stroke="black"/>
-<path d="M 224,16 L 224,80" fill="none" stroke="black"/>
-<path d="M 224,160 L 224,256" fill="none" stroke="black"/>
-<path d="M 272,80 L 272,152" fill="none" stroke="black"/>
-<path d="M 328,16 L 328,80" fill="none" stroke="black"/>
-<path d="M 328,160 L 328,256" fill="none" stroke="black"/>
-<path d="M 8,16 L 120,16" fill="none" stroke="black"/>
-<path d="M 224,16 L 328,16" fill="none" stroke="black"/>
-<path d="M 120,48 L 216,48" fill="none" stroke="black"/>
-<path d="M 8,80 L 120,80" fill="none" stroke="black"/>
-<path d="M 224,80 L 328,80" fill="none" stroke="black"/>
-<path d="M 24,160 L 104,160" fill="none" stroke="black"/>
-<path d="M 224,160 L 328,160" fill="none" stroke="black"/>
-<path d="M 128,208 L 224,208" fill="none" stroke="black"/>
-<path d="M 328,208 L 392,208" fill="none" stroke="black"/>
-<path d="M 24,256 L 104,256" fill="none" stroke="black"/>
-<path d="M 224,256 L 328,256" fill="none" stroke="black"/>
-<path d="M 24,160 C 15.16936,160 8,167.16936 8,176" fill="none" stroke="black"/>
-<path d="M 104,160 C 112.83064,160 120,167.16936 120,176" fill="none" stroke="black"/>
-<path d="M 24,256 C 15.16936,256 8,248.83064 8,240" fill="none" stroke="black"/>
-<path d="M 104,256 C 112.83064,256 120,248.83064 120,240" fill="none" stroke="black"/>
-<polygon class="arrowhead" points="400,208 388,202.4 388,213.6" fill="black" transform="rotate(0,392,208)"/>
-<polygon class="arrowhead" points="280,152 268,146.4 268,157.6" fill="black" transform="rotate(90,272,152)"/>
-<polygon class="arrowhead" points="224,48 212,42.4 212,53.6" fill="black" transform="rotate(0,216,48)"/>
-<polygon class="arrowhead" points="136,208 124,202.4 124,213.6" fill="black" transform="rotate(180,128,208)"/>
-<polygon class="arrowhead" points="64,88 52,82.4 52,93.6" fill="black" transform="rotate(270,56,88)"/>
+<path d="M 8,16L 8,80"/>
+<path d="M 8,176L 8,240"/>
+<path d="M 56,81.18235L 56,160"/>
+<path d="M 120,16L 120,80"/>
+<path d="M 120,176L 120,240"/>
+<path d="M 224,16L 224,80"/>
+<path d="M 224,160L 224,256"/>
+<path d="M 272,80L 272,158.81765"/>
+<path d="M 328,16L 328,80"/>
+<path d="M 328,160L 328,256"/>
+<path d="M 8,16L 120,16"/>
+<path d="M 224,16L 328,16"/>
+<path d="M 120,48L 222.81765,48"/>
+<path d="M 8,80L 120,80"/>
+<path d="M 224,80L 328,80"/>
+<path d="M 24,160L 104,160"/>
+<path d="M 224,160L 328,160"/>
+<path d="M 121.18235,208L 224,208"/>
+<path d="M 328,208L 398.81765,208"/>
+<path d="M 24,256L 104,256"/>
+<path d="M 224,256L 328,256"/>
+<path d="M 24,160C 15.16936,160 8,167.16936 8,176"/>
+<path d="M 104,160C 112.83064,160 120,167.16936 120,176"/>
+<path d="M 24,256C 15.16936,256 8,248.83064 8,240"/>
+<path d="M 104,256C 112.83064,256 120,248.83064 120,240"/>
+<path class="arrowhead" d="M 387.78856,202.85309 L 398.81765,208 L 387.78856,213.14691"/>
+<path class="arrowhead" d="M 277.14691,147.78856 L 272,158.81765 L 266.85309,147.78856"/>
+<path class="arrowhead" d="M 211.78856,42.85309 L 222.81765,48 L 211.78856,53.14691"/>
+<path class="arrowhead" d="M 132.21144,213.14691 L 121.18235,208 L 132.21144,202.85309"/>
+<path class="arrowhead" d="M 50.85309,92.21144 L 56,81.18235 L 61.14691,92.21144"/>
 <g class="text">
 <text x="60" y="52">User</text>
 <text x="276" y="52">Advertiser</text>


### PR DESCRIPTION
The new release of aasvg makes smaller, neater images, so use that.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/412.html" title="Last updated on Apr 29, 2026, 6:51 AM UTC (62dfb20)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/412/f37dcf5...62dfb20.html" title="Last updated on Apr 29, 2026, 6:51 AM UTC (62dfb20)">Diff</a>