### PR TITLE
Define a locking mechanism

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1210,7 +1210,11 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
     with |key|, |l1NormDeduction|, |valueDeduction|,
     |impressions|, and |isSingleEpoch|
-    is false, return false.
+    is false, perform the following steps:
+
+    1.  Set [=attribution budget lock=] to false.
+
+    1.  Return false.
 
 1.  All budget checks passed, so perform the deductions:
 

--- a/api.bs
+++ b/api.bs
@@ -1081,13 +1081,6 @@ that are used to manage the expenditure of [=privacy budgets=]:
 *   The [=privacy budget store=] records the state
     of the per-[=site=] and per-[=epoch=] [=privacy budgets=].
 
-*   The [=epoch start time=] records when the first [=epoch=] starts.
-    This value is initialized as a side effect
-    of invoking <a method for=Attribution>measureConversion()</a>.
-
-*   A singular [=last browsing history clear=] value
-    that tracks when the browsing activity for a [=site=] was last cleared.
-
 *   The [=global privacy budget store=] records the state
     of the per-[=epoch=] global [=privacy budget=]
     that applies across all [=sites=].
@@ -1095,9 +1088,20 @@ that are used to manage the expenditure of [=privacy budgets=]:
 *   The [=impression site quota store=] records the state
     of per-[=impression site=] and per-[=epoch=] quota for comsuming from the [=global privacy budget store=].
 
-*   The [=privacy budget store=], [=global privacy budget store=],
-    and [=impression site quota store=] are updated by [=deduct privacy and safety budgets=].
+*   The [=epoch start time=] is used to determine when [=epochs=] start.
+    This value is initialized as a side effect
+    of invoking <a method for=Attribution>measureConversion()</a>.
 
+*   A singular [=last browsing history clear=] value
+    that tracks when the browsing activity for a [=site=] was last cleared.
+
+*   A singular <dfn>attribution budget lock</dfn> is a boolean flag
+    that is used to prevent concurrent operations
+    on privacy budget stores,
+    which might otherwise lead to overexpenditure of budgets.
+
+The [=privacy budget store=], [=global privacy budget store=],
+and [=impression site quota store=] are updated by [=deduct privacy and safety budgets=].
 
 <p class=note>
 Like the [=impression store=],
@@ -1106,10 +1110,13 @@ These stores have some additional constraints
 on how information is cleared;
 see [[#clear-budget-store]] for details.
 
-<p class=issue>
-Some references to clearing
-the [=impression store=] may need to be
-updated to refer to the [=privacy budget store=] as well.
+<p class=note>
+The choice to define the [=attribution budget lock=] as a boolean flag
+is a matter of specification expediency.
+Implementations might be better served by an alternative construct.
+Implementations might be able to partition this value,
+such as by [=epoch=],
+to reduce the scope of any contention.
 
 
 ### Privacy Budget Store ### {#s-privacy-budget-store}
@@ -1196,6 +1203,10 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
 1.  Let |valueDeduction| be |valueDeductionFp| * 1000000, rounded towards positive Infinity.
 
+1.  If [=attribution budget lock=] is true,
+    wait until the value becomes false,
+    then set the value to true.
+
 1.  If the result of invoking [=check for available privacy budget|checking for available privacy budget=]
     with |key|, |l1NormDeduction|, |valueDeduction|,
     |impressions|, and |isSingleEpoch|
@@ -1239,6 +1250,8 @@ and a [=set=] of [=epoch indices=] |deductedGlobalBudgets|:
 
             1.  [=map/set|Set=] the value of [=impression site quota per epoch=]\[|impressionQuotaKey|\]
                 to |currentImpressionQuotaValue| − |valueDeduction|.
+
+1.  Set [=attribution budget lock=] to false.
 
 1.  Return true.
 


### PR DESCRIPTION
This takes a very simple approach to locking, so that checks on privacy budget and subsequent expenditure are covered by a lock.

I've opted for a simple boolean flag, but have noted that a different mechanism is likely necessary in practice.  I took a look at the infra spec and the web locks API, but was unable to find a primitive that might have been a better fit.

Closes #371.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/415.html" title="Last updated on May 2, 2026, 4:04 AM UTC (326a0c5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/415/f37dcf5...326a0c5.html" title="Last updated on May 2, 2026, 4:04 AM UTC (326a0c5)">Diff</a>