### PR TITLE
Pass document, not window, to check attribution API activation algorithm

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1829,9 +1829,8 @@ and [=implicit API inputs=] |implicitInputs|:
 1.  If |document| is not [=allowed to use=] the [=policy-controlled feature=] named
     "{{PermissionPolicy/measure-conversion}}", return [=a promise rejected with=]
     a {{"NotAllowedError"}} {{DOMException}} in |realm|.
-1.  Let |window| be |document|'s [=relevant global object=].
 1.  [=check attribution API activation|Check attribution API activation=]
-    given |window|, returning [=a promise rejected with=] any thrown reason.
+    given |document|, returning [=a promise rejected with=] any thrown reason.
 1.  Let |validatedOptions| be the result of
     [=validate AttributionConversionOptions|validating=] |options|,
     returning [=a promise rejected with=] any thrown reason.


### PR DESCRIPTION
The algorithm takes the former, which is already passed properly by the save an impression algorithm.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/apasel422/ppa-api/pull/419.html" title="Last updated on May 12, 2026, 3:21 PM UTC (33a7b0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/419/a7f306f...apasel422:33a7b0d.html" title="Last updated on May 12, 2026, 3:21 PM UTC (33a7b0d)">Diff</a>