### PR TITLE
Credit needs to be finite

### DIFF
--- a/api.bs
+++ b/api.bs
@@ -1929,7 +1929,10 @@ To <dfn>validate {{AttributionConversionOptions}}</dfn> |options|:
     throw a {{RangeError}}.
 1.  Let |credit| be |options|.{{AttributionConversionOptions/credit}} if it [=map/exists=], «1» otherwise.
 1.  If |credit| [=list/is empty=], throw a {{RangeError}}.
-1.  If any of the [=list/items=] of |credit| are less than or equal to 0, throw a {{RangeError}}.
+1.  If any of the [=list/items=] of |credit| are
+    not [finite](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.isfinite)
+    or less than or equal to 0,
+    throw a {{RangeError}}.
 1.  If the [=list/size=] of |credit| exceeds the [=implementation-defined=]
     [=maximum number of credit values=], throw a {{RangeError}}.
 1.  Let |lookback| be |options|.{{AttributionConversionOptions/lookbackDays}} [=days=]


### PR DESCRIPTION
We don't specify a maximum value in the same way we do for epsilon, so this would have accepted `Infinity`, which isn't exactly going to work out well.  Now, `[Number.MAX_VALUE, Number.MAX_VALUE]` still leads to a bad outcome, but trying to prevent that sort of nonsense isn't something I think we need to over-index on. 

The implementation already checks that the value is finite; this just has the spec catch up.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/pull/439.html" title="Last updated on May 26, 2026, 1:17 AM UTC (731322e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/attribution/439/b2461cc...731322e.html" title="Last updated on May 26, 2026, 1:17 AM UTC (731322e)">Diff</a>